### PR TITLE
Installs mock_safety_sensors in the BIN destination folder too

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ catkin_package()
          scripts/mock_battery
          scripts/mock_led_strip
          scripts/mock_component
+         scripts/mock_safety_sensors
          scripts/tutorial_dashboard
          scripts/tutorial_tree
      DESTINATION


### PR DESCRIPTION
When running the tutorials when installed from the ROS repo, it complains that the program mock_safety_sensors does not exist. This is actually true (good job ROS!) and I realized that that script is not installed with the rest. I don't know if there is a mysterious reason for that but if not, here is the fix.

Error: 
```
ERROR: cannot launch node of type [py_trees_ros/mock_safety_sensors]: can't locate node [mock_safety_sensors] in package [py_trees_ros]
```