### PR TITLE
[py_trees_ros][actions] feedback msg from action_client

### DIFF
--- a/py_trees_ros/actions.py
+++ b/py_trees_ros/actions.py
@@ -43,13 +43,15 @@ class ActionClient(py_trees.behaviour.Behaviour):
         action_goal (:obj:`any`): preconfigured action goal (e.g. move_base_msgs.msg.MoveBaseGoal())
         action_namespace (:obj:`str`): where you can find the action topics
     """
-    def __init__(self, name="Action Client", action_spec=None, action_goal=None, action_namespace="/action"):
+    def __init__(self, name="Action Client", action_spec=None, action_goal=None, action_namespace="/action",
+                 feedback_message_on_running="moving"):
         super(ActionClient, self).__init__(name)
         self.action_client = None
         self.sent_goal = False
         self.action_spec = action_spec
         self.action_goal = action_goal
         self.action_namespace = action_namespace
+        self.feedback_message_on_running = feedback_message_on_running
 
     def setup(self, timeout):
         """
@@ -94,16 +96,15 @@ class ActionClient(py_trees.behaviour.Behaviour):
             self.sent_goal = True
             self.feedback_message = "sent goal to the action server"
             return py_trees.Status.RUNNING
-        if self.action_client.get_state() == actionlib_msgs.GoalStatus.ABORTED:
-            result = self.action_client.get_result()
-            self.feedback_message = result.message
+        self.feedback_message = self.action_client.get_goal_status_text()
+        if self.action_client.get_state() in [actionlib_msgs.GoalStatus.ABORTED,
+                                              actionlib_msgs.GoalStatus.PREEMPTED]:
             return py_trees.Status.FAILURE
         result = self.action_client.get_result()
         if result:
-            self.feedback_message = "goal reached"
             return py_trees.Status.SUCCESS
         else:
-            self.feedback_message = "moving"
+            self.feedback_message = self.feedback_message_on_running
             return py_trees.Status.RUNNING
 
     def terminate(self, new_status):

--- a/py_trees_ros/actions.py
+++ b/py_trees_ros/actions.py
@@ -42,16 +42,24 @@ class ActionClient(py_trees.behaviour.Behaviour):
         action_spec (:obj:`any`): spec type for the action (e.g. move_base_msgs.msg.MoveBaseAction)
         action_goal (:obj:`any`): preconfigured action goal (e.g. move_base_msgs.msg.MoveBaseGoal())
         action_namespace (:obj:`str`): where you can find the action topics
+        override_feedback_message_on_running (:obj:`str`): override the feedback message from the server
+
+    Feedback messages are often accompanied with detailed messages that continuously change - since these
+    are not significant and we don't want to log every change due to these messages, you can provide an override
+    here that simply signifies the action is running.
+
+    @todo: a more comprehensive way of filtering/parsing feedback messages to customise a running state so
+    that it can identify and react to 'significant' events while running.
     """
     def __init__(self, name="Action Client", action_spec=None, action_goal=None, action_namespace="/action",
-                 feedback_message_on_running="moving"):
+                 override_feedback_message_on_running="moving"):
         super(ActionClient, self).__init__(name)
         self.action_client = None
         self.sent_goal = False
         self.action_spec = action_spec
         self.action_goal = action_goal
         self.action_namespace = action_namespace
-        self.feedback_message_on_running = feedback_message_on_running
+        self.override_feedback_message_on_running = override_feedback_message_on_running
 
     def setup(self, timeout):
         """
@@ -104,7 +112,7 @@ class ActionClient(py_trees.behaviour.Behaviour):
         if result:
             return py_trees.Status.SUCCESS
         else:
-            self.feedback_message = self.feedback_message_on_running
+            self.feedback_message = self.override_feedback_message_on_running
             return py_trees.Status.RUNNING
 
     def terminate(self, new_status):

--- a/py_trees_ros/tutorials/five.py
+++ b/py_trees_ros/tutorials/five.py
@@ -159,7 +159,8 @@ def create_root():
         name="Rotate",
         action_namespace="/rotate",
         action_spec=py_trees_msgs.RotateAction,
-        action_goal=py_trees_msgs.RotateGoal()
+        action_goal=py_trees_msgs.RotateGoal(),
+        override_feedback_message_on_running="rotating"
     )
     scan_flash_blue = py_trees_ros.tutorials.behaviours.FlashLedStrip(name="Flash Blue", colour="blue")
     scan_celebrate = py_trees.composites.Parallel(name="Celebrate", policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ONE)

--- a/py_trees_ros/tutorials/jobs.py
+++ b/py_trees_ros/tutorials/jobs.py
@@ -111,7 +111,8 @@ class Scan(object):
             name="UnDock",
             action_namespace="/dock",
             action_spec=py_trees_msgs.DockAction,
-            action_goal=py_trees_msgs.DockGoal(False)
+            action_goal=py_trees_msgs.DockGoal(False),
+            override_feedback_message_on_running="undocking"
         )
         scan_or_be_cancelled = py_trees.composites.Selector("Scan or Be Cancelled")
         cancelling = py_trees.composites.Sequence("Cancelling?")
@@ -135,11 +136,13 @@ class Scan(object):
         )
         scanning = py_trees.composites.Parallel(name="Scanning", policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ONE)
         scan_context_switch = py_trees_ros.tutorials.behaviours.ScanContext("Context Switch")
+        rospy.logwarn("Setting up rotating")
         scan_rotate = py_trees_ros.actions.ActionClient(
             name="Rotate",
             action_namespace="/rotate",
             action_spec=py_trees_msgs.RotateAction,
-            action_goal=py_trees_msgs.RotateGoal()
+            action_goal=py_trees_msgs.RotateGoal(),
+            override_feedback_message_on_running="rotating"
         )
         scan_flash_blue = py_trees_ros.tutorials.behaviours.FlashLedStrip(name="Flash Blue", colour="blue")
         move_home_after_scan = py_trees_ros.actions.ActionClient(
@@ -155,7 +158,8 @@ class Scan(object):
             name="Dock",
             action_namespace="/dock",
             action_spec=py_trees_msgs.DockAction,
-            action_goal=py_trees_msgs.DockGoal(True)
+            action_goal=py_trees_msgs.DockGoal(True),
+            override_feedback_message_on_running="docking"
         )
         # Subtree
         root.add_children([ere_we_go, die])

--- a/py_trees_ros/tutorials/seven.py
+++ b/py_trees_ros/tutorials/seven.py
@@ -120,7 +120,8 @@ def create_root():
         name="UnDock",
         action_namespace="/dock",
         action_spec=py_trees_msgs.DockAction,
-        action_goal=py_trees_msgs.DockGoal(False)
+        action_goal=py_trees_msgs.DockGoal(False),
+        override_feedback_message_on_running="undocking"
     )
     scan_or_be_cancelled = py_trees.composites.Selector("Scan or Be Cancelled")
     cancelling = py_trees.composites.Sequence("Cancelling?")
@@ -148,7 +149,8 @@ def create_root():
         name="Rotate",
         action_namespace="/rotate",
         action_spec=py_trees_msgs.RotateAction,
-        action_goal=py_trees_msgs.RotateGoal()
+        action_goal=py_trees_msgs.RotateGoal(),
+        override_feedback_message_on_running="rotating"
     )
     scan_flash_blue = py_trees_ros.tutorials.behaviours.FlashLedStrip(name="Flash Blue", colour="blue")
     move_home_after_scan = py_trees_ros.actions.ActionClient(
@@ -164,7 +166,8 @@ def create_root():
         name="Dock",
         action_namespace="/dock",
         action_spec=py_trees_msgs.DockAction,
-        action_goal=py_trees_msgs.DockGoal(True)
+        action_goal=py_trees_msgs.DockGoal(True),
+        override_feedback_message_on_running="docking"
     )
     idle = py_trees.behaviours.Running(name="Idle")
 

--- a/py_trees_ros/tutorials/six.py
+++ b/py_trees_ros/tutorials/six.py
@@ -144,7 +144,8 @@ def create_root():
         name="Rotate",
         action_namespace="/rotate",
         action_spec=py_trees_msgs.RotateAction,
-        action_goal=py_trees_msgs.RotateGoal()
+        action_goal=py_trees_msgs.RotateGoal(),
+        override_feedback_message_on_running="rotating"
     )
     scan_flash_blue = py_trees_ros.tutorials.behaviours.FlashLedStrip(name="Flash Blue", colour="blue")
     scan_celebrate = py_trees.composites.Parallel(name="Celebrate", policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ONE)

--- a/tests/rostests/Readme.md
+++ b/tests/rostests/Readme.md
@@ -5,3 +5,12 @@ I can never remember how to run them...
 ```
 rostest --text mytest.test
 ```
+
+To connect to the default roscore port (so that you can introspect / separate nodes etc):
+
+```
+# in a first shell
+roscore
+# in a second shell (reuse the current roscore and clear parameters)
+rostest -r -c --text mytest.test
+```


### PR DESCRIPTION
The feedback is retrieved from `action_client.get_goal_status_text()` which is set by `set_x(.., msg)` in the corresponding action server.

The default text for `status.ACTIVE` is `This goal has been accepted by the simple action server`, for which a argument is added to provide a bit more context wrt to action (e.g move_base -> "moving", rotate -> "rotating" etc)