### PR TITLE
ACTION_CLIENT: Remove print statement for goal

### DIFF
--- a/py_trees_ros/actions.py
+++ b/py_trees_ros/actions.py
@@ -99,7 +99,6 @@ class ActionClient(py_trees.behaviour.Behaviour):
             return py_trees.Status.INVALID
         # pity there is no 'is_connected' api like there is for c++
         if not self.sent_goal:
-            print("Goal %s" % str(self.action_goal))
             self.action_client.send_goal(self.action_goal)
             self.sent_goal = True
             self.feedback_message = "sent goal to the action server"


### PR DESCRIPTION
Remove the print statement that prints the goal in the ActionClient class in actions.py because it can be very annoying if you have large goals. For example if your goal has a point cloud in it.