### PR TITLE
[blacboard_exchange] add unregister services function to blackboard.Exchange class

### DIFF
--- a/py_trees_ros/blackboard.py
+++ b/py_trees_ros/blackboard.py
@@ -150,6 +150,9 @@ class Exchange(object):
         self.cached_blackboard_dict = {}
         self.watchers = []
         self.publisher = None
+        self.get_blackboard_variables_srv = None
+        self.open_blackboard_watcher_srv = None
+        self.close_blackboard_watcher_srv = None
 
     def setup(self, timeout):
         """
@@ -184,9 +187,9 @@ class Exchange(object):
         .. seealso:: This method is called in the way illustrated above in :class:`~py_trees_ros.trees.BehaviourTree`.
         """
         self.publisher = rospy.Publisher("~blackboard", std_msgs.String, latch=True, queue_size=2)
-        rospy.Service('~get_blackboard_variables', py_trees_srvs.GetBlackboardVariables, self._get_blackboard_variables_service)
-        rospy.Service('~open_blackboard_watcher', py_trees_srvs.OpenBlackboardWatcher, self._open_blackboard_watcher_service)
-        rospy.Service('~close_blackboard_watcher', py_trees_srvs.CloseBlackboardWatcher, self._close_blackboard_watcher_service)
+        self.get_blackboard_variables_srv = rospy.Service('~get_blackboard_variables', py_trees_srvs.GetBlackboardVariables, self._get_blackboard_variables_service)
+        self.open_blackboard_watcher_srv = rospy.Service('~open_blackboard_watcher', py_trees_srvs.OpenBlackboardWatcher, self._open_blackboard_watcher_service)
+        self.close_blackboard_watcher_srv = rospy.Service('~close_blackboard_watcher', py_trees_srvs.CloseBlackboardWatcher, self._close_blackboard_watcher_service)
         return True
 
     def _get_nested_keys(self):
@@ -267,3 +270,8 @@ class Exchange(object):
             watcher = _View(topic_name, req.variables)
             self.watchers.append(watcher)
         return py_trees_srvs.OpenBlackboardWatcherResponse(topic_name)
+
+    def unregister_services(self):
+        for srv in [self.get_blackboard_variables_srv, self.open_blackboard_watcher_srv, self.close_blackboard_watcher_srv]:
+            if srv is not None:
+                srv.shutdown()

--- a/py_trees_ros/blackboard.py
+++ b/py_trees_ros/blackboard.py
@@ -272,6 +272,13 @@ class Exchange(object):
         return py_trees_srvs.OpenBlackboardWatcherResponse(topic_name)
 
     def unregister_services(self):
+        """
+        Use this method to make sure services are cleaned up when you wish
+        to subsequently discard the Exchange instance. This should be a
+        fairly atypical use case however - first consider if there are
+        ways to modify trees on the fly instead of destructing/recreating
+        all of the peripheral machinery.
+        """
         for srv in [self.get_blackboard_variables_srv, self.open_blackboard_watcher_srv, self.close_blackboard_watcher_srv]:
             if srv is not None:
                 srv.shutdown()


### PR DESCRIPTION
`  File "/home/user/catkin_ws/src/mobile_manipulation/py_trees_ros/py_trees_ros/blackboard.py", line 199, in setup
    self.get_blackboard_variables_srv = rospy.Service('~get_blackboard_variables', py_trees_srvs.GetBlackboardVariables, self._get_blackboard_variables_service)
  File "/opt/ros/indigo/lib/python2.7/dist-packages/rospy/impl/tcpros_service.py", line 712, in __init__
    get_service_manager().register(self.resolved_name, self)
  File "/opt/ros/indigo/lib/python2.7/dist-packages/rospy/service.py", line 116, in register
    raise ServiceException(err)
rospy.service.ServiceException: service [/lfd/get_blackboard_variables] already registered
`
**rospy.service.ServiceException: service [/lfd/get_blackboard_variables] already registered**

Rospy does not automatically unregister services when the destructor is called.
This leads to problems when using multiple instances of blackboard.Exchange class.
If a second blackboard.Exchange class's setup function is called you get the above error.
As a workaround I added a function to the blackboard exchange to unregister all services.

This solution won't work if you actually want two blacboard.Exchange classes running in the same node at the same time but it will let you stop one and start another which is what I need.

There may be better options like a function to set the name of the services but this works for my needs so I thought I'd share it.

Side note I tried to unregister services automatically with __del__ but ran into issues.