### PR TITLE
[trees|subscribers|battery] enable ros2 behaviours

### DIFF
--- a/py_trees_ros/__init__.py
+++ b/py_trees_ros/__init__.py
@@ -14,17 +14,17 @@ ROS extensions, behaviours and utilities for py_trees.
 # Imports
 ##############################################################################
 
+from . import battery
 from . import blackboard
 # from . import exceptions
 from . import programs
+from . import subscribers
 from . import trees
 # from . import tutorials
 from . import utilities
 
 # from . import actions
-# from . import battery
 # from . import conversions
-# from . import subscribers
 # from . import visitors
 
 ##############################################################################

--- a/py_trees_ros/battery.py
+++ b/py_trees_ros/battery.py
@@ -17,7 +17,6 @@ Getting the most out of your battery.
 ##############################################################################
 
 import py_trees
-import rospy
 import sensor_msgs.msg as sensor_msgs
 
 from . import subscribers
@@ -73,7 +72,8 @@ class ToBlackboard(subscribers.ToBlackboard):
                 self.blackboard.battery_low_warning = False
             elif self.blackboard.battery.percentage < self.threshold:
                     self.blackboard.battery_low_warning = True
-                    rospy.logwarn_throttle(60, "%s: battery level is low!" % self.name)
+                    # TODO: make this throttled
+                    self.node.get_logger().error("{}: battery level is low!".format(self.name))
             # else don't do anything in between - i.e. avoid the ping pong problems
 
             self.feedback_message = "Battery level is low" if self.blackboard.battery_low_warning else "Battery level is ok"

--- a/py_trees_ros/battery.py
+++ b/py_trees_ros/battery.py
@@ -46,12 +46,12 @@ class ToBlackboard(subscribers.ToBlackboard):
         threshold (:obj:`float`) : percentage level threshold for flagging as low (0-100)
     """
     def __init__(self, name, topic_name="/battery/state", threshold=30.0):
-        super(ToBlackboard, self).__init__(name=name,
-                                           topic_name=topic_name,
-                                           topic_type=sensor_msgs.BatteryState,
-                                           blackboard_variables={"battery": None},
-                                           clearing_policy=py_trees.common.ClearingPolicy.NEVER
-                                           )
+        super().__init__(name=name,
+                         topic_name=topic_name,
+                         topic_type=sensor_msgs.BatteryState,
+                         blackboard_variables={"battery": None},
+                         clearing_policy=py_trees.common.ClearingPolicy.NEVER
+                         )
         self.blackboard = py_trees.blackboard.Blackboard()
         self.blackboard.battery = sensor_msgs.BatteryState()
         self.blackboard.battery.percentage = 0.0

--- a/py_trees_ros/blackboard.py
+++ b/py_trees_ros/blackboard.py
@@ -208,7 +208,6 @@ class Exchange(object):
                 srv_name='~/' + name,
                 callback=getattr(self, "_{}_service".format(name))
             )
-        return True
 
     def _get_nested_keys(self):
         variables = []

--- a/py_trees_ros/blackboard.py
+++ b/py_trees_ros/blackboard.py
@@ -34,6 +34,7 @@ import py_trees.console as console
 import py_trees_ros_interfaces.srv as py_trees_srvs
 import rclpy.executors
 import rclpy.expand_topic_name
+import rclpy.node
 import std_msgs.msg as std_msgs
 import time
 
@@ -149,29 +150,24 @@ class Exchange(object):
     _counter = 0
     """Incremental counter guaranteeing unique watcher names"""
 
-    def __init__(self,
-                 node_name=py_trees.common.Name.AUTO_GENERATED,
-                 namespace=""):
-        if not node_name or node_name == py_trees.common.Name.AUTO_GENERATED:
-                node_name = self.__class__.__name__.lower()
+    def __init__(self):
         self.node = None
         self.blackboard = py_trees.blackboard.Blackboard()
         self.cached_blackboard_dict = {}
         self.views = []
         self.publisher = None
         self.services = {}
-        self.parameters = {
-            "node_name": node_name,
-            "namespace": namespace
-        }
 
-    def setup(self):
+    def setup(self, node: rclpy.node.Node):
         """
         This is where the ros initialisation of publishers and services happens. It is kept
         outside of the constructor for the same reasons that the familiar py_trees
         :meth:`~py_trees.trees.BehaviourTree.setup` method has - to enable construction
         of behaviours and trees offline (away from their execution environment) so that
         dot graphs and other visualisations of the tree can be created.
+
+        Args:
+            node (:class:`~rclpy.node.Node`): node to hook ros communications on
 
         Examples:
 
@@ -191,21 +187,15 @@ class Exchange(object):
 
         .. seealso:: This method is called in the way illustrated above in :class:`~py_trees_ros.trees.BehaviourTree`.
         """
-        self.node = rclpy.create_node(
-            node_name=self.parameters["node_name"],
-            namespace=self.parameters["namespace"],
-            start_parameter_services=False
-        )
-
-        self.publisher = self.node.create_publisher(std_msgs.String, '~/blackboard')
-
+        self.node = node
+        self.publisher = self.node.create_publisher(std_msgs.String, '~/exchange/blackboard')
         for name in ["get_blackboard_variables",
                      "open_blackboard_watcher",
                      "close_blackboard_watcher"]:
             camel_case_name = ''.join(x.capitalize() for x in name.split('_'))
             self.services[name] = self.node.create_service(
                 srv_type=getattr(py_trees_srvs, camel_case_name),
-                srv_name='~/' + name,
+                srv_name='~/exchange/' + name,
                 callback=getattr(self, "_{}_service".format(name))
             )
 
@@ -261,6 +251,9 @@ class Exchange(object):
             return
 
         # publish blackboard
+        #   the blackboard watcher doesn't actually use the lazy publisher, but
+        #   if latching and string formatting in ROS gets up to speed, it will be a
+        #   more useful thing to have around - easy to detect and rostopic echo the contents
         if self.node.count_subscribers("~/blackboard") > 0:
             if self._is_changed():
                 msg = std_msgs.String()
@@ -398,7 +391,7 @@ class BlackboardWatcher(object):
                         callback=None,
                         executor=None):
         """
-        First alls the exchange to get details on the connect the watcher is required
+        First calls the exchange to get details on the connect the watcher is required
         to open and then initiates that tunnel. Note that this does some spinning waiting
         for the service call, so if the executor must be shared with other nodes (e.g. for
         testing) make sure you pass in your own executor.

--- a/py_trees_ros/conversions.py
+++ b/py_trees_ros/conversions.py
@@ -23,8 +23,6 @@ import rclpy
 import unique_identifier_msgs.msg as unique_identifier_msgs
 import uuid
 
-from . import utilities
-
 ##############################################################################
 # <etjpds
 ##############################################################################

--- a/py_trees_ros/programs/blackboard_watcher.py
+++ b/py_trees_ros/programs/blackboard_watcher.py
@@ -151,7 +151,6 @@ def main(command_line_args=sys.argv[1:]):
     ####################
     try:
         if args.list_variables:
-            # pretty_print_variables(blackboard_watcher.list_variables())
             future = blackboard_watcher.request_list_variables()
             rclpy.spin_until_future_complete(blackboard_watcher.node, future)
             if future.result() is None:

--- a/py_trees_ros/subscribers.py
+++ b/py_trees_ros/subscribers.py
@@ -28,9 +28,10 @@ permitted to be used or written to the blackboard.
 import copy
 import operator
 import py_trees
-import rospy
 import std_msgs.msg as std_msgs
 import threading
+
+from . import utilities
 
 ##############################################################################
 # Behaviours
@@ -74,12 +75,14 @@ class Handler(py_trees.behaviour.Behaviour):
         name (:obj:`str`): name of the behaviour
         topic_name (:obj:`str`): name of the topic to connect to
         topic_type (:obj:`any`): class of the message type (e.g. :obj:`std_msgs.msg.String`)
+        qos_profile (:obj:`bool`): qos profile for the subscriber
         clearing_policy (:class:`~py_trees.common.ClearingPolicy`): when to clear the data
     """
     def __init__(self,
                  name="Subscriber Handler",
                  topic_name="/foo",
                  topic_type=None,
+                 qos_profile=utilities.qos_profile_latched_topic(),
                  clearing_policy=py_trees.common.ClearingPolicy.ON_INITIALISE
                  ):
         super(Handler, self).__init__(name)
@@ -89,21 +92,31 @@ class Handler(py_trees.behaviour.Behaviour):
         self.subscriber = None
         self.data_guard = threading.Lock()
         self.clearing_policy = clearing_policy
+        self.qos_profile = qos_profile
+        self.node = None
 
-    def setup(self, timeout):
+    def setup(self, **kwargs):
         """
         Initialises the subscriber.
 
         Args:
-            timeout (:obj:`float`): time to wait (0.0 is blocking forever)
+            **kwargs (:obj:`dict`): distribute arguments to this
+               behaviour and in turn, all of it's children
 
-        Returns:
-            :obj:`bool`: whether it timed out trying to setup
+        Raises:
+            KeyError: if a ros2 node isn't passed under the key 'node' in kwargs
         """
-        # ros doesn't care if it is init'd or not for subscriber construction, but
-        # good to have here anyway so initialisation can occur before the callback is connected
-        self.subscriber = rospy.Subscriber(self.topic_name, self.topic_type, self._callback, queue_size=5)
-        return True
+        try:
+            self.node = kwargs['node']
+        except KeyError as e:
+            error_message = "didn't find 'node' in setup's kwargs [{}][{}]".format(self.name, self.__class__.__name__)
+            raise KeyError(error_message) from e  # 'direct cause' traceability
+        self.node.create_subscription(
+            msg_type=self.topic_type,
+            topic=self.topic_name,
+            callback=self._callback,
+            qos_profile=self.qos_profile
+        )
 
     def initialise(self):
         """
@@ -149,6 +162,7 @@ class CheckData(Handler):
         name (:obj:`str`): name of the behaviour
         topic_name (:obj:`str`): name of the topic to connect to
         topic_type (:obj:`any`): class of the message type (e.g. :obj:`std_msgs.msg.String`)
+        qos_profile (:obj:`bool`): qos profile for the subscriber
         variable_name (:obj:`str`): name of the variable to check
         expected_value (:obj:`any`): expected value of the variable
         fail_if_no_data (:obj:`bool`): :attr:`~py_trees.common.Status.FAILURE` instead of :attr:`~py_trees.common.Status.RUNNING` if there is no data yet
@@ -168,6 +182,7 @@ class CheckData(Handler):
                  name="Check Data",
                  topic_name="/foo",
                  topic_type=None,
+                 qos_profile=utilities.qos_profile_latched_topic(),
                  variable_name="bar",
                  expected_value=None,
                  fail_if_no_data=False,
@@ -179,6 +194,7 @@ class CheckData(Handler):
             name,
             topic_name=topic_name,
             topic_type=topic_type,
+            qos_profile=qos_profile,
             clearing_policy=clearing_policy,
         )
         self.variable_name = variable_name
@@ -205,22 +221,24 @@ class CheckData(Handler):
         try:
             value = check_attr(msg)
         except AttributeError:
-            rospy.logerr("Behaviours [%s" % self.name + "]: variable name not found [%s]" % self.variable_name)
-            print("%s" % msg)
+            self.node.get_logger().error("Behaviour [{}]: variable name not found [{}]".format(self.name, self.variable_name))
+            print("{}".format(msg))
             with self.data_guard:
-                self.feedback_message = "variable name not found [%s]" % self.variable_name
+                self.feedback_message = "variable name not found [{}]".format(self.variable_name)
                 return py_trees.common.Status.FAILURE
 
         success = self.comparison_operator(value, self.expected_value)
 
         if success:
-            self.feedback_message = "'%s' comparison succeeded [v: %s][e: %s]" % (self.variable_name, value, self.expected_value)
+            self.feedback_message = "'{}' comparison succeeded [v: {}][e: {}]".format(
+                self.variable_name, value, self.expected_value)
             if self.clearing_policy == py_trees.common.ClearingPolicy.ON_SUCCESS:
                 with self.data_guard:
                     self.msg = None
             return py_trees.common.Status.SUCCESS
         else:
-            self.feedback_message = "'%s' comparison failed [v: %s][e: %s]" % (self.variable_name, value, self.expected_value)
+            self.feedback_message = "'{}' comparison failed [v: {}][e: {}]".format(
+                self.variable_name, value, self.expected_value)
             return py_trees.common.Status.FAILURE if self.fail_if_bad_comparison else py_trees.common.Status.RUNNING
 
 
@@ -260,18 +278,21 @@ class WaitForData(Handler):
         name (:obj:`str`): name of the behaviour
         topic_name (:obj:`str`): name of the topic to connect to
         topic_type (:obj:`any`): class of the message type (e.g. :obj:`std_msgs.msg.String`)
+        qos_profile (:obj:`bool`): qos profile for the subscriber
         clearing_policy (:class:`~py_trees.common.ClearingPolicy`): when to clear the data
     """
     def __init__(self,
                  name="Wait For Data",
                  topic_name="chatter",
                  topic_type=None,
+                 qos_profile=utilities.qos_profile_latched_topic(),
                  clearing_policy=py_trees.common.ClearingPolicy.ON_INITIALISE
                  ):
         super(WaitForData, self).__init__(
             name,
             topic_name=topic_name,
             topic_type=topic_type,
+            qos_profile=qos_profile,
             clearing_policy=clearing_policy
         )
 
@@ -305,6 +326,7 @@ class ToBlackboard(Handler):
         name (:obj:`str`): name of the behaviour
         topic_name (:obj:`str`): name of the topic to connect to
         topic_type (:obj:`any`): class of the message type (e.g. :obj:`std_msgs.msg.String`)
+        qos_profile (:obj:`bool`): qos profile for the subscriber
         blackboard_variables (:obj:`dict`): blackboard variable string or dict {names (keys) - message subfields (values)}, use a value of None to indicate the entire message
         initialise_variables (:obj:`bool`): initialise the blackboard variables to some defaults
         clearing_policy (:class:`~py_trees.common.ClearingPolicy`): when to clear the data
@@ -339,6 +361,7 @@ class ToBlackboard(Handler):
                  name="ToBlackboard",
                  topic_name="chatter",
                  topic_type=None,
+                 qos_profile=utilities.qos_profile_latched_topic(),
                  blackboard_variables={"chatter": None},
                  initialise_variables={},
                  clearing_policy=py_trees.common.ClearingPolicy.ON_INITIALISE
@@ -347,11 +370,12 @@ class ToBlackboard(Handler):
             name,
             topic_name=topic_name,
             topic_type=topic_type,
+            qos_profile=qos_profile,
             clearing_policy=clearing_policy
         )
         self.logger = py_trees.logging.Logger("%s" % self.name)
         self.blackboard = py_trees.blackboard.Blackboard()
-        if isinstance(blackboard_variables, basestring):
+        if isinstance(blackboard_variables, str):
             self.blackboard_variable_mapping = {blackboard_variables: None}
             if not isinstance(initialise_variables, dict):
                 self.blackboard_initial_variable_mapping = {blackboard_variables: initialise_variables}
@@ -365,22 +389,10 @@ class ToBlackboard(Handler):
             self.blackboard_variable_mapping = blackboard_variables
             self.blackboard_initial_variable_mapping = initialise_variables
         # initialise the variables
-        for name, value in self.blackboard_initial_variable_mapping.iteritems():
+        for name, value in self.blackboard_initial_variable_mapping.items():
             if not self.blackboard.set(name, value):
                 # do we actually want to log an error?
                 self.logger.error("tried to initialise an already initialised blackboard variable '{0}', check that you do not have a conflict with another behaviour [{1}]".format(name, self.name))
-
-    def setup(self, timeout):
-        """
-        Initialise the subscriber.
-
-        Args:
-            timeout (:obj:`float`): time to wait (0.0 is blocking forever)
-
-        Returns:
-            :obj:`bool`: whether it timed out trying to setup
-        """
-        return super(ToBlackboard, self).setup(timeout)
 
     def update(self):
         """
@@ -428,21 +440,24 @@ class EventToBlackboard(Handler):
     Args:
         name (:obj:`str`): name of the behaviour
         topic_name (:obj:`str`): name of the topic to connect to
+        qos_profile (:obj:`bool`): qos profile for the subscriber
         variable_name (:obj:`str`): name to write the boolean result on the blackboard
     """
     def __init__(self,
                  name="Event to Blackboard",
                  topic_name="/event",
+                 qos_profile=utilities.qos_profile_latched_topic(),
                  variable_name="event"
                  ):
         super(EventToBlackboard, self).__init__(
             name=name,
             topic_name=topic_name,
             topic_type=std_msgs.Empty,
+            qos_profile=qos_profile,
             clearing_policy=py_trees.common.ClearingPolicy.ON_SUCCESS
         )
         self.variable_name = variable_name
-        self.blackboard = py_trees.Blackboard()
+        self.blackboard = py_trees.blackboard.Blackboard()
 
     def update(self):
         """

--- a/py_trees_ros/subscribers.py
+++ b/py_trees_ros/subscribers.py
@@ -28,6 +28,7 @@ permitted to be used or written to the blackboard.
 import copy
 import operator
 import py_trees
+import rclpy.qos
 import std_msgs.msg as std_msgs
 import threading
 
@@ -82,7 +83,7 @@ class Handler(py_trees.behaviour.Behaviour):
                  name="Subscriber Handler",
                  topic_name="/foo",
                  topic_type=None,
-                 qos_profile=utilities.qos_profile_latched_topic(),
+                 qos_profile=rclpy.qos.qos_profile_default,
                  clearing_policy=py_trees.common.ClearingPolicy.ON_INITIALISE
                  ):
         super(Handler, self).__init__(name)
@@ -111,11 +112,11 @@ class Handler(py_trees.behaviour.Behaviour):
         except KeyError as e:
             error_message = "didn't find 'node' in setup's kwargs [{}][{}]".format(self.name, self.__class__.__name__)
             raise KeyError(error_message) from e  # 'direct cause' traceability
-        self.node.create_subscription(
+        self.subscriber = self.node.create_subscription(
             msg_type=self.topic_type,
             topic=self.topic_name,
             callback=self._callback,
-            qos_profile=self.qos_profile
+            # qos_profile=self.qos_profile
         )
 
     def initialise(self):
@@ -406,7 +407,7 @@ class ToBlackboard(Handler):
                 self.feedback_message = "no message received yet"
                 return py_trees.common.Status.RUNNING
             else:
-                for k, v in self.blackboard_variable_mapping.iteritems():
+                for k, v in self.blackboard_variable_mapping.items():
                     if v is None:
                         self.blackboard.set(k, self.msg, overwrite=True)
                     else:

--- a/py_trees_ros/trees.py
+++ b/py_trees_ros/trees.py
@@ -140,11 +140,12 @@ class BehaviourTree(py_trees.trees.BehaviourTree):
             return RuntimeError("rlcpy not yet initialised [{}]".format(default_node_name))
         self._setup_publishers()
         self.blackboard_exchange = blackboard.Exchange()
-        if not self.blackboard_exchange.setup():
-            return False
+        self.blackboard_exchange.setup()
         self.post_tick_handlers.append(self._on_change_post_tick_handler)
         self.post_tick_handlers.append(self.blackboard_exchange.publish_blackboard)
-        super().setup(timeout)
+
+        # share the tree's node with it's behaviours
+        super().setup(timeout, node=self.node)
 
     def _setup_publishers(self):
         latched = True

--- a/py_trees_ros/trees.py
+++ b/py_trees_ros/trees.py
@@ -23,7 +23,7 @@ with a few ROS style adornments. The major features currently include:
 ##############################################################################
 
 import collections
-import datetime
+# import datetime
 import enum
 import functools
 import os
@@ -32,7 +32,6 @@ import py_trees
 import py_trees.console as console
 import py_trees_ros_interfaces.msg as py_trees_msgs
 # import rosbag
-# TODO: import rospkg
 import rclpy
 import statistics
 import subprocess
@@ -42,9 +41,7 @@ import unique_identifier_msgs.msg as unique_identifier_msgs
 
 from . import blackboard
 from . import conversions
-from . import exceptions
 from . import utilities
-from . import visitors
 
 ##############################################################################
 # ROS Trees
@@ -325,6 +322,7 @@ class BehaviourTree(py_trees.trees.BehaviourTree):
 
     def _ascii_tree_post_tick_handler(self, snapshot_visitor, tree):
         print(
+            "\n" +
             py_trees.display.ascii_tree(
                 tree.root,
                 visited=snapshot_visitor.visited,

--- a/py_trees_ros/trees.py
+++ b/py_trees_ros/trees.py
@@ -140,7 +140,7 @@ class BehaviourTree(py_trees.trees.BehaviourTree):
             return RuntimeError("rlcpy not yet initialised [{}]".format(default_node_name))
         self._setup_publishers()
         self.blackboard_exchange = blackboard.Exchange()
-        self.blackboard_exchange.setup()
+        self.blackboard_exchange.setup(self.node)
         self.post_tick_handlers.append(self._on_change_post_tick_handler)
         self.post_tick_handlers.append(self.blackboard_exchange.publish_blackboard)
 

--- a/py_trees_ros/utilities.py
+++ b/py_trees_ros/utilities.py
@@ -18,13 +18,12 @@ Assorted utility functions.
 
 import os
 import pathlib
-import uuid
 
 import py_trees_ros_interfaces.msg as py_trees_msgs
 import py_trees_ros_interfaces.srv as py_trees_srvs
 import rclpy
+import rclpy.qos
 import time
-import unique_identifier_msgs.msg as unique_identifier_msgs
 
 from . import exceptions
 
@@ -268,12 +267,9 @@ class Subscribers(object):
         for (name, topic_name, subscriber_type, latched, callback) in subscriber_details:
             if latched:
                 self.__dict__[name] = node.create_subscription(
-                    subscriber_type,
-                    topic_name,
-                    callback,
-                    # msg_type=subscriber_type,
-                    # topic=topic_name,
-                    # callback=callback,
+                    msg_type=subscriber_type,
+                    topic=topic_name,
+                    callback=callback,
                     qos_profile=qos_profile_latched_topic()
                 )
             else:


### PR DESCRIPTION
And apply to the battery / subscriber behaviours.

Needed to take advantage of the new **kwargs approach via setup to pass a ros2 node into the behaviour (which subsequently needed to avoid multiprocessing `setup()` back in `py_trees`). The alternative is to let behaviours fire up nodes individually and collect them back out the front, but that would leave you with a multi-node process which is problematic for ros2 launch right now.