### PR TITLE
[behaviours] action client

### DIFF
--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,10 @@
+eclipse.preferences.version=1
+encoding//py_trees_ros/actions.py=utf-8
+encoding//py_trees_ros/battery.py=utf-8
+encoding//py_trees_ros/blackboard.py=utf-8
+encoding//py_trees_ros/exceptions.py=utf-8
+encoding//py_trees_ros/mock/actions.py=utf-8
+encoding//py_trees_ros/mock/dock.py=utf-8
+encoding//py_trees_ros/subscribers.py=utf-8
+encoding//py_trees_ros/trees.py=utf-8
+encoding//tests/test_action_client.py=utf-8

--- a/py_trees_ros/__init__.py
+++ b/py_trees_ros/__init__.py
@@ -19,6 +19,7 @@ from . import battery
 from . import blackboard
 from . import conversions
 from . import exceptions
+from . import mock
 from . import programs
 from . import subscribers
 from . import trees

--- a/py_trees_ros/actions.py
+++ b/py_trees_ros/actions.py
@@ -16,7 +16,13 @@ Behaviours for ROS actions.
 # Imports
 ##############################################################################
 
+import action_msgs.msg as action_msgs  # GoalStatus
 import py_trees
+import rclpy.action
+
+from typing import Any, Callable
+
+from . import exceptions
 
 ##############################################################################
 # Behaviours
@@ -27,10 +33,47 @@ class ActionClient(py_trees.behaviour.Behaviour):
     """
     A generic action client interface. This simply sends a pre-configured
     goal to the action client.
+
+    Args:
+        action_type (:obj:`any`): spec type for the action (e.g. move_base_msgs.msg.MoveBaseAction)
+        action_name (:obj:`str`): where you can find the action topics & services (e.g. "bob/move_base")
+        action_goal (:obj:`any`): pre-configured action goal (e.g. move_base_msgs.action.MoveBaseGoal())
+        name (:obj:`str`, optional): name of the behaviour defaults to lowercase class name
+        generate_feedback_message (:obj:`func`, optional): formatter for feedback messages, takes action_type.Feedback
+            messages and returns strings, defaults to None
     """
-    def __init__(self, name=py_trees.common.Name.AUTO_GENERATED):
+    def __init__(self,
+                 action_type,
+                 action_name,
+                 action_goal,
+                 name: str=py_trees.common.Name.AUTO_GENERATED,
+                 generate_feedback_message: Callable[[Any], str]=None,
+                 ):
         super().__init__(name)
+        self.action_type = action_type
+        self.action_name = action_name
+        self.action_goal = action_goal
+        self.generate_feedback_message = generate_feedback_message
+
         self.node = None
+        self.action_client = None
+        self.goal_handle = None
+        self.send_goal_future = None
+        self.get_result_future = None
+
+        self.result_message = None
+        self.result_status = None
+        self.result_status_string = None
+
+        self.status_strings = {
+                action_msgs.GoalStatus.STATUS_UNKNOWN : "STATUS_UNKNOWN",  # noqa
+                action_msgs.GoalStatus.STATUS_ACCEPTED : "STATUS_ACCEPTED",  # noqa
+                action_msgs.GoalStatus.STATUS_EXECUTING: "STATUS_EXECUTING",  # noqa
+                action_msgs.GoalStatus.STATUS_CANCELING: "STATUS_CANCELING",  # noqa
+                action_msgs.GoalStatus.STATUS_SUCCEEDED: "STATUS_SUCCEEDED",  # noqa
+                action_msgs.GoalStatus.STATUS_CANCELED : "STATUS_CANCELED",  # noqa
+                action_msgs.GoalStatus.STATUS_ABORTED  : "STATUS_ABORTED"  # noqa
+            }
 
     def setup(self, **kwargs):
         """
@@ -42,18 +85,41 @@ class ActionClient(py_trees.behaviour.Behaviour):
 
         Raises:
             KeyError: if a ros2 node isn't passed under the key 'node' in kwargs
+            TimedOutError: if the action server could not be found
         """
+        self.logger.debug("{}.setup()".format(self.qualified_name))
         try:
             self.node = kwargs['node']
         except KeyError as e:
-            error_message = "didn't find 'node' in setup's kwargs [{}][{}]".format(self.name, self.__class__.__name__)
+            error_message = "didn't find 'node' in setup's kwargs [{}][{}]".format(self.qualified_name)
             raise KeyError(error_message) from e  # 'direct cause' traceability
+
+        self.action_client = rclpy.action.ActionClient(
+            node=self.node,
+            action_type=self.action_type,
+            action_name=self.action_name
+        )
+        self.node.get_logger().info(
+            "waiting for server ... [{}][{}]".format(
+                self.action_name, self.qualified_name
+            )
+        )
+        result = self.action_client.wait_for_server(timeout_sec=2.0)
+        if not result:
+            message = "timed out waiting for the server [{}]".format(
+                    self.action_name
+                )
+            self.node.get_logger().error(message)
+            raise exceptions.TimedOutError(message)
+        else:
+            self.node.get_logger().info("... connected [{}]".format(self.qualified_name))
 
     def initialise(self):
         """
         Reset the internal variables.
         """
-        self.logger.debug("{0}.initialise()".format(self.__class__.__name__))
+        self.logger.debug("{}.initialise()".format(self.qualified_name))
+        self.send_goal_request()
 
     def update(self):
         """
@@ -61,8 +127,18 @@ class ActionClient(py_trees.behaviour.Behaviour):
         succeeded, is running, or has cancelled/aborted for some reason and
         map these to the usual behaviour return states.
         """
-        self.logger.debug("{0}.update()".format(self.__class__.__name__))
-        return py_trees.common.Status.SUCCESS
+        self.logger.debug("{}.update()".format(self.qualified_name))
+
+        if self.result_status is None:
+            return py_trees.common.Status.RUNNING
+        else:
+            self.node.get_logger().info("goal result [{}]".format(self.qualified_name))
+            self.node.get_logger().info("  status: {}".format(self.result_status_string))
+            self.node.get_logger().info("  message: {}".format(self.result_message))
+            if self.result_status == action_msgs.GoalStatus.STATUS_SUCCEEDED:  # noqa
+                return py_trees.common.Status.SUCCESS
+            else:
+                return py_trees.common.Status.FAILURE
 
     def terminate(self, new_status):
         """
@@ -71,4 +147,77 @@ class ActionClient(py_trees.behaviour.Behaviour):
         Args:
             new_status (:class:`~py_trees.common.Status`): the behaviour is transitioning to this new status
         """
-        self.logger.debug("%s.terminate(%s)" % (self.__class__.__name__, "%s->%s" % (self.status, new_status) if self.status != new_status else "%s" % new_status))
+        self.logger.debug(
+            "{}.terminate({})".format(
+                self.qualified_name,
+                "{}->{}".format(self.status, new_status) if self.status != new_status else "{}".format(new_status)
+            )
+        )
+        self.send_cancel_request()
+
+    ########################################
+    # Action Client Methods
+    ########################################
+    def feedback_callback(self, msg):
+        if self.generate_feedback_message is not None:
+            self.node.get_logger().info(
+                'feedback: {} [{}]'.format(
+                    self.generate_feedback_message(msg),
+                    self.qualified_name
+                )
+            )
+
+    def send_goal_request(self):
+        """
+        Send the goal and get a future back, but don't do any
+        spinning here to await the future result.
+
+        Returns:
+            :class:`rclpy.task.Future`
+        """
+        self.node.get_logger().info('sending goal ... [{}]'.format(self.qualified_name))
+        self.send_goal_future = self.action_client.send_goal_async(
+                self.action_goal,
+                feedback_callback=self.feedback_callback,
+                # A random uuid is always generated, since we're not sending more than one
+                # at a time, we don't need to generate and track them here
+                # goal_uuid=unique_identifier_msgs.UUID(uuid=list(uuid.uuid4().bytes))
+        )
+        self.send_goal_future.add_done_callback(self.goal_response_callback)
+
+    def goal_response_callback(self, future):
+        """
+        Handle goal response, proceed to listen for the result if accepted.
+        """
+        self._goal_handle = future.result()
+        if not self._goal_handle.accepted:
+            self.node.get_logger().info('... goal rejected :( [{}]\n{!r}'.format(self.qualified_name, future.exception()))
+            return
+        self.node.get_logger().info("... goal accepted :) [{}]".format(self.qualified_name))
+        self.node.get_logger().debug("  {!s}".format(future.result()))
+
+        self.get_result_future = self._goal_handle.get_result_async()
+        self.get_result_future.add_done_callback(self.get_result_callback)
+
+    def send_cancel_request(self):
+
+        self.node.get_logger().info('cancelling goal ... [{}]'.format(self.qualified_name))
+
+        if self.goal_handle is not None:
+            future = self._goal_handle.cancel_goal_async()
+            future.add_done_callback(self.cancel_response_callback)
+
+    def cancel_response_callback(self, future):
+        cancel_response = future.result()
+        if len(cancel_response.goals_canceling) > 0:
+            self.node.get_logger().info('... goal successfully cancelled [{}]'.format(self.qualified_name))
+        else:
+            self.node.get_logger().info('... goal failed to cancel [{}]'.format(self.qualified_name))
+
+    def get_result_callback(self, future):
+        """
+        Handle result.
+        """
+        self.result_message = future.result().message
+        self.result_status = future.result().action_status
+        self.result_status_string = self.status_strings[self.result_status]

--- a/py_trees_ros/actions.py
+++ b/py_trees_ros/actions.py
@@ -158,7 +158,6 @@ class ActionClient(py_trees.behaviour.Behaviour):
         """
         Clean up the action client when shutting down.
         """
-        print("SHUUTTTTTDOOOOWNNNN")
         self.action_client.destroy()
 
     ########################################
@@ -235,6 +234,7 @@ class ActionClient(py_trees.behaviour.Behaviour):
         """
         Handle result.
         """
+        print("Done: %s" % future.done())
         self.result_message = future.result()
         self.result_status = future.result().action_status
         self.result_status_string = self.status_strings[self.result_status]

--- a/py_trees_ros/mock/__init__.py
+++ b/py_trees_ros/mock/__init__.py
@@ -1,0 +1,17 @@
+#
+# License: BSD
+#   https://raw.githubusercontent.com/stonier/py_trees_ros/devel/LICENSE
+#
+##############################################################################
+# Documentation
+##############################################################################
+
+"""
+This package contains mock ROS nodes for py_trees tests.
+"""
+##############################################################################
+# Imports
+##############################################################################
+
+from . import actions
+from . import dock

--- a/py_trees_ros/mock/actions.py
+++ b/py_trees_ros/mock/actions.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# License: BSD
+#   https://raw.githubusercontent.com/splintered-reality/py_trees_ros_tutorials/devel/LICENSE
+#
+##############################################################################
+# Documentation
+##############################################################################
+
+"""
+Action server/client templates.
+"""
+
+##############################################################################
+# Imports
+##############################################################################
+
+import rclpy
+import rclpy.action
+import rclpy.callback_groups
+import rclpy.parameter
+import threading
+import time
+
+##############################################################################
+# Action Server
+##############################################################################
+#
+# References:
+#
+#  action client         : https://github.com/ros2/rclpy/blob/master/rclpy/rclpy/action/client.py
+#  action server         : https://github.com/ros2/rclpy/blob/master/rclpy/rclpy/action/server.py
+#  action client PR      : https://github.com/ros2/rclpy/pull/257
+#  action server PR      : https://github.com/ros2/rclpy/pull/270
+#  action examples       : https://github.com/ros2/examples/tree/master/rclpy/actions
+#
+# Note:
+#  currently:  py_trees_ros_interfaces.action.Dock_Goal.Request()
+#  to come(?): py_trees_ros_interfaces.action.Dock.GoalRequestService.Request()
+
+
+class GenericServer(object):
+    """
+    Generic action server that can be subclassed to quickly create action
+    servers of varying types in a mock simulation.
+
+    Dynamic Reconfigure:
+        * **~duration** (:obj:`float`)
+
+          * reconfigure the duration to be used for the next goal execution
+
+    Args:
+        node_name (:obj:`str`): name to use for the node (e.g. docking_controller)
+        action_name (:obj:`str`): name of the action server (e.g. dock)
+        action_type (:obj:`any`): type of the action server (e.g. py_trees_ros_interfaces.Dock
+        custom_execute_callback (:obj:`func`): callback to be executed inside the execute loop, no args
+        goal_recieved_callback(:obj:`func`): callback to be executed immediately upon receiving a goal
+        duration (:obj:`float`): forcibly override the dyn reconf time for a goal to complete (seconds)
+
+    Use the ``dashboard`` to dynamically reconfigure the parameters.
+
+    There are some shortcomings in this class that could be addressed to make it more robust:
+
+     - check for matching goal id's when disrupting execution
+     - execute multiple requests in parallel / pre-emption (not even tried)
+    """
+    def __init__(self,
+                 node_name,
+                 action_name,
+                 action_type,  # e.g. py_trees_ros_interfaces.action.Dock
+                 generate_feedback_message=None,
+                 goal_received_callback=lambda request: None,
+                 duration=None):
+        self.node = rclpy.create_node(
+            node_name,
+            initial_parameters=[
+                rclpy.parameter.Parameter(
+                    'duration',
+                    rclpy.parameter.Parameter.Type.DOUBLE,
+                    5.0  # seconds
+                ),
+            ]
+        )
+        # override
+        if duration is not None:
+            self.node.set_parameters([
+                rclpy.parameter.Parameter(
+                    'duration',
+                    rclpy.parameter.Parameter.Type.DOUBLE,
+                    duration  # seconds
+                ),
+            ])
+        # Needs a member variable to capture the dynamic parameter
+        # value when accepting the goal and pass that to the execution
+        # of the goal. Not necessary to initialise here, but done
+        # for completeness
+        self.duration = self.node.get_parameter("duration").value
+
+        self.goal_handle = None
+        self.goal_lock = threading.Lock()
+        self.frequency = 3.0  # hz
+        self.percent_completed = 0
+
+        self.action_type = action_type
+        if generate_feedback_message is None:
+            self.generate_feedback_message = lambda: self.action_type.Feedback()
+        else:
+            self.generate_feedback_message = generate_feedback_message
+        self.goal_received_callback = goal_received_callback
+        self.goal_handle = None
+        self.preempt_goal_ids = []  # list of unique_identifier_msgs.UUID (goal_id's)
+
+        self.action_server = rclpy.action.ActionServer(
+            node=self.node,
+            action_type=self.action_type,
+            action_name=action_name,
+            callback_group=rclpy.callback_groups.ReentrantCallbackGroup(),  # needed?
+            cancel_callback=self.cancel_callback,
+            execute_callback=self.execute_goal_callback,
+            goal_callback=self.goal_callback,
+            handle_accepted_callback=self.handle_accepted_callback,
+            result_timeout=10
+        )
+
+    def goal_callback(self, goal_request):
+        """
+        Args:
+            goal_request: of <action_type>.GoalRequest with members
+                goal_id (unique_identifier.msgs.UUID) and those specified in the action
+        """
+        self.node.get_logger().info("received a goal")
+        self.goal_received_callback(goal_request)
+        self.percent_completed = 0
+        self.duration = self.node.get_parameter("duration").value
+        return rclpy.action.server.GoalResponse.ACCEPT
+
+    def cancel_callback(
+            self,
+            goal_handle: rclpy.action.server.ServerGoalHandle
+         ) -> rclpy.action.CancelResponse:
+        """
+        No cancellations.
+
+        Args:
+            cancel_request (:class:`~rclpy.action.server.ServerGoalHandle`):
+                handle with information about the
+                goal that is requested to be cancelled
+        """
+        self.node.get_logger().info("cancel requested: [{goal_id}]".format(
+            goal_id=goal_handle.goal_id))
+        return rclpy.action.CancelResponse.ACCEPT
+
+    def execute_goal_callback(
+            self,
+            goal_handle: rclpy.action.server.ServerGoalHandle
+         ):
+        """
+        Check for pre-emption, but otherwise just spin around gradually incrementing
+        a hypothetical 'percent' done.
+
+        Args:
+            goal_handle (:class:`~rclpy.action.server.ServerGoalHandle`): the goal handle of the executing action
+        """
+        # goal.details (e.g. pose) = don't care
+        self.node.get_logger().info("executing a goal")
+        increment = 100 / (self.frequency * self.duration)
+        while True:
+            # TODO: use a rate when they have it
+            time.sleep(1.0 / self.frequency)
+            self.percent_completed += increment
+            with self.goal_lock:
+                if goal_handle.is_active:
+                    if goal_handle.goal_id in self.preempt_goal_ids:
+                        self.preempt_goal_ids.remove(goal_handle.goal_id)
+                        result = self.action_type.Result()
+                        result.message = "goal pre-empted at {percentage:.2f}%%".format(
+                            percentage=self.percent_completed)
+                        self.node.get_logger().info(result.message)
+                        goal_handle.set_aborted()
+                        return result
+                    elif goal_handle.is_cancel_requested:
+                        result = self.action_type.Result()
+                        result.message = "goal cancelled at {percentage:.2f}%%".format(
+                            percentage=self.percent_completed)
+                        self.node.get_logger().info(result.message)
+                        goal_handle.set_canceled()
+                        return result
+                    elif self.percent_completed >= 100.0:
+                        self.percent_completed = 100.0
+                        self.node.get_logger().info("feedback 100%%")
+                        result = self.action_type.Result()
+                        result.message = "goal executed with success"
+                        self.node.get_logger().info(result.message)
+                        goal_handle.set_succeeded()
+                        return result
+                    else:
+                        self.node.get_logger().info("feedback {percentage:.2f}%%".format(
+                            percentage=self.percent_completed))
+                        goal_handle.publish_feedback(
+                            self.generate_feedback_message()
+                        )
+                else:  # ! active
+                    self.node.get_logger().info("goal is no longer active, aborting")
+                    result = self.action_type.Result()
+                    return result
+
+    def handle_accepted_callback(self, goal_handle):
+        self.node.get_logger().info("handle accepted")
+        with self.goal_lock:
+            if self.goal_handle is not None:
+                self.node.get_logger().info("pre-empting")
+                self.preempt_goal_ids.append(self.goal_handle.goal_id)
+            self.goal_handle = goal_handle
+            goal_handle.execute()
+
+    def abort(self):
+        """
+        This method is typically only used when the system is shutting down and
+        there is an executing goal that needs to be abruptly terminated.
+        """
+        with self.goal_lock:
+            if self.goal_handle and self.goal_handle.is_active:
+                self.node.get_logger().info("aborting...")
+                self.goal_handle.set_aborted()
+
+    def shutdown(self):
+        """
+        Cleanup
+        """
+        self.action_server.destroy()
+        self.node.destroy_node()

--- a/py_trees_ros/mock/actions.py
+++ b/py_trees_ros/mock/actions.py
@@ -140,7 +140,7 @@ class GenericServer(object):
             goal_handle: rclpy.action.server.ServerGoalHandle
          ) -> rclpy.action.CancelResponse:
         """
-        No cancellations.
+        Cancel any currently executing goal
 
         Args:
             cancel_request (:class:`~rclpy.action.server.ServerGoalHandle`):
@@ -188,14 +188,14 @@ class GenericServer(object):
                         return result
                     elif self.percent_completed >= 100.0:
                         self.percent_completed = 100.0
-                        self.node.get_logger().info("feedback 100%%")
+                        self.node.get_logger().info("sending feedback 100%%")
                         result = self.action_type.Result()
                         result.message = "goal executed with success"
                         self.node.get_logger().info(result.message)
                         goal_handle.set_succeeded()
                         return result
                     else:
-                        self.node.get_logger().info("feedback {percentage:.2f}%%".format(
+                        self.node.get_logger().info("sending feedback {percentage:.2f}%%".format(
                             percentage=self.percent_completed))
                         goal_handle.publish_feedback(
                             self.generate_feedback_message()

--- a/py_trees_ros/mock/dock.py
+++ b/py_trees_ros/mock/dock.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# License: BSD
+#   https://raw.githubusercontent.com/splintered-reality/py_trees_ros/devel/LICENSE
+#
+##############################################################################
+# Documentation
+##############################################################################
+
+"""
+Mocks a docking controller
+"""
+
+
+##############################################################################
+# Imports
+##############################################################################
+
+import py_trees_ros_interfaces.action as py_trees_actions
+
+from . import actions
+
+##############################################################################
+# Class
+##############################################################################
+
+
+class Dock(actions.GenericServer):
+    """
+    Simple server that docks if the goal is true, undocks otherwise.
+    """
+    def __init__(self, duration=2.0):
+        super().__init__(
+            node_name="docking_controller",
+            action_name="dock",
+            action_type=py_trees_actions.Dock,
+            generate_feedback_message=self.generate_feedback_message,
+            goal_received_callback=self.goal_received_callback,
+            duration=duration
+        )
+
+    def goal_received_callback(self, goal):
+        if goal.dock:
+            self.title = "Dock"
+        else:
+            self.title = "UnDock"
+
+    def generate_feedback_message(self):
+        """
+        Create some appropriate feedback.
+        """
+        # TODO: send some feedback message
+        msg = py_trees_actions.Dock_Feedback(
+            percentage_completed=self.percent_completed
+        )
+        return msg

--- a/py_trees_ros/trees.py
+++ b/py_trees_ros/trees.py
@@ -41,6 +41,7 @@ import unique_identifier_msgs.msg as unique_identifier_msgs
 
 from . import blackboard
 from . import conversions
+from . import exceptions
 from . import utilities
 
 ##############################################################################
@@ -128,13 +129,12 @@ class BehaviourTree(py_trees.trees.BehaviourTree):
             timeout (:obj:`float`): time (s) to wait (use common.Duration.INFINITE to block indefinitely)
 
         Raises:
+            rclpy.exceptions.NotInitializedException: rclpy not yet initialised
             Exception: be ready to catch if any of the behaviours raise an exception
         """
         default_node_name = "tree"
-        try:
-            self.node = rclpy.create_node(default_node_name)
-        except rclpy.exceptions.NotInitializedException:
-            return RuntimeError("rlcpy not yet initialised [{}]".format(default_node_name))
+        # rclpy.create_node can raise rclpy.exceptions.NotInitializedException
+        self.node = rclpy.create_node(default_node_name)
         self._setup_publishers()
         self.blackboard_exchange = blackboard.Exchange()
         self.blackboard_exchange.setup(self.node)
@@ -142,7 +142,13 @@ class BehaviourTree(py_trees.trees.BehaviourTree):
         self.post_tick_handlers.append(self.blackboard_exchange.publish_blackboard)
 
         # share the tree's node with it's behaviours
-        super().setup(timeout, node=self.node)
+        try:
+            super().setup(timeout, node=self.node)
+        except RuntimeError as e:
+            if str(e) == "tree setup timed out":
+                raise exceptions.TimedOutError("tree setup timed out")
+            else:
+                raise
 
     def _setup_publishers(self):
         latched = True

--- a/py_trees_ros/trees.py
+++ b/py_trees_ros/trees.py
@@ -209,6 +209,7 @@ class BehaviourTree(py_trees.trees.BehaviourTree):
             self.timer.cancel()
             self.node.destroy_timer(self.timer)
         self.node.destroy_node()
+        super().shutdown()
 
     def _tick_tock_timer_callback(
             self,

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,15 @@
+# Tests
+
+Make sure you source the environment to run tests.
+
+## Executing Tests
+
+```
+# run all tests will full stdout
+$ python3 -m unittest discover
+# run a single test
+$ cd tests && python3 ./test_action_client.py
+# step back and run from setup.py (what colcon does)
+$ python3 setup.py test
+```
+

--- a/tests/test_action_client.py
+++ b/tests/test_action_client.py
@@ -86,7 +86,7 @@ class TestActionServers(unittest.TestCase):
 # Success
 ##############################################################################
 
-    def foo_test_success(self):
+    def test_success(self):
         console.banner("Client Success")
 
         root = create_action_client()
@@ -119,19 +119,23 @@ class TestActionServers(unittest.TestCase):
         assert_details("root.status", "SUCCESS", root.status)
         self.assertEqual(root.status, py_trees.common.Status.SUCCESS)
 
-        tree.shutdown()
-        executor.shutdown()
+        # 1. segfaults galore if I try to shut things down
+        # 2. if I don't shutdown, publishers/services aren't closed down and
+        #    you get the "Publisher already registered for provided node name."
+        #    warning.
+        # executor.shutdown()
+        # tree.shutdown()
 
     def test_priority_interrupt(self):
         console.banner("Priority Interrupt")
 
-        number_of_iterations = 5
+        number_of_iterations = 50
 
         action_client = create_action_client()
         success_eventually = py_trees.behaviours.Count(
             name="Success Eventually",
-            fail_until=number_of_iterations-1,
-            success_until=100
+            fail_until=4,
+            success_until=1000
         )
         root = py_trees.composites.Selector()
         root.add_children([success_eventually, action_client])
@@ -155,18 +159,18 @@ class TestActionServers(unittest.TestCase):
             number_of_iterations=number_of_iterations
         )
 
-        while tree.count < number_of_iterations:
+        while tree.count < number_of_iterations and "cancelled" not in action_client.feedback_message:
             executor.spin_once(timeout_sec=0.1)
         print_ascii_tree(tree)
         assert_details("action_client.status", "INVALID", action_client.status)
         self.assertEqual(action_client.status, py_trees.common.Status.INVALID)
 
-        try:
-            executor.spin()
-        except KeyboardInterrupt:
-            pass
-        tree.shutdown()
-        executor.shutdown()
+        # 1. segfaults galore if I try to shut things down
+        # 2. if I don't shutdown, publishers/services aren't closed down and
+        #    you get the "Publisher already registered for provided node name."
+        #    warning.
+        # executor.shutdown()
+        # tree.shutdown()
 
 ##############################################################################
 # Preemption

--- a/tests/test_action_client.py
+++ b/tests/test_action_client.py
@@ -11,8 +11,9 @@
 
 import action_msgs.msg as action_msgs  # GoalStatus
 import py_trees
-import py_trees_ros
 import py_trees.console as console
+import py_trees_ros
+import py_trees_ros_interfaces.action as py_trees_actions
 import rclpy
 import rclpy.executors
 import time
@@ -34,6 +35,28 @@ def assert_details(text, expected, result):
           console.yellow + " [{}]".format(result) +
           console.reset)
 
+
+def create_action_client():
+    behaviour = py_trees_ros.actions.ActionClient(
+        name="dock",
+        action_type=py_trees_actions.Dock,
+        action_name="dock",
+        action_goal=py_trees_actions.Dock.Goal(dock=True),
+        generate_feedback_message=lambda msg: "{:.2f}%%".format(msg.percentage_completed)
+    )
+    return behaviour
+
+
+def print_ascii_tree(tree):
+    print(
+        "\n" +
+        py_trees.display.ascii_tree(
+            tree.root,
+            visited=tree.snapshot_visitor.visited,
+            previously_visited=tree.snapshot_visitor.previously_visited
+        )
+    )
+
 ##############################################################################
 # Tests
 ##############################################################################
@@ -45,7 +68,7 @@ class TestActionServers(unittest.TestCase):
     def setUpClass(cls):
         console.banner("ROS Init")
         rclpy.init()
-        cls.server = py_trees_ros.mock.dock.Dock(duration=0.5)
+        cls.server = py_trees_ros.mock.dock.Dock(duration=1.5)
 
         cls.timeout = 3.0
         cls.blackboard = py_trees.blackboard.Blackboard()
@@ -63,29 +86,87 @@ class TestActionServers(unittest.TestCase):
 # Success
 ##############################################################################
 
-    def generic_success_test(
-            self,
-            title
-         ):
-        console.banner(title)
+    def foo_test_success(self):
+        console.banner("Client Success")
 
-        root = py_trees_ros.actions.ActionClient(name="foo")
-        root.setup()
+        root = create_action_client()
+        tree = py_trees_ros.trees.BehaviourTree(root=root, ascii_tree_debug=False)
+        tree.setup()
 
         executor = rclpy.executors.MultiThreadedExecutor(num_threads=4)
         executor.add_node(self.server.node)
-        # executor.add_node(client.node)
-
-        root.tick_once()
+        executor.add_node(tree.node)
 
         assert_banner()
+
+        assert_details("root.status", "INVALID", root.status)
+        self.assertEqual(root.status, py_trees.common.Status.INVALID)
+
+        tree.tick()
+
         assert_details("root.status", "RUNNING", root.status)
+        self.assertEqual(root.status, py_trees.common.Status.RUNNING)
 
+        number_of_iterations = 100
+        tree.tick_tock(
+            period_ms=100,
+            number_of_iterations=number_of_iterations
+        )
+
+        while tree.count < number_of_iterations and root.status == py_trees.common.Status.RUNNING:
+            executor.spin_once(timeout_sec=0.05)
+
+        assert_details("root.status", "SUCCESS", root.status)
+        self.assertEqual(root.status, py_trees.common.Status.SUCCESS)
+
+        tree.shutdown()
         executor.shutdown()
-        # client.shutdown()
 
-    def test_client_success(self):
-        self.generic_success_test(title="Client Success")
+    def test_priority_interrupt(self):
+        console.banner("Priority Interrupt")
+
+        number_of_iterations = 5
+
+        action_client = create_action_client()
+        success_eventually = py_trees.behaviours.Count(
+            name="Success Eventually",
+            fail_until=number_of_iterations-1,
+            success_until=100
+        )
+        root = py_trees.composites.Selector()
+        root.add_children([success_eventually, action_client])
+        tree = py_trees_ros.trees.BehaviourTree(root=root, ascii_tree_debug=False)
+        tree.setup()
+
+        executor = rclpy.executors.MultiThreadedExecutor(num_threads=4)
+        executor.add_node(self.server.node)
+        executor.add_node(tree.node)
+
+        assert_banner()
+
+        tree.tick()
+        print_ascii_tree(tree)
+
+        assert_details("action_client.status", "RUNNING", root.status)
+        self.assertEqual(action_client.status, py_trees.common.Status.RUNNING)
+
+        tree.tick_tock(
+            period_ms=100,
+            number_of_iterations=number_of_iterations
+        )
+
+        while tree.count < number_of_iterations:
+            executor.spin_once(timeout_sec=0.1)
+        print_ascii_tree(tree)
+        assert_details("action_client.status", "INVALID", action_client.status)
+        self.assertEqual(action_client.status, py_trees.common.Status.INVALID)
+
+        try:
+            executor.spin()
+        except KeyboardInterrupt:
+            pass
+        tree.shutdown()
+        executor.shutdown()
 
 ##############################################################################
 # Preemption

--- a/tests/test_action_client.py
+++ b/tests/test_action_client.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# License: BSD
+#   https://raw.githubusercontent.com/splintered-reality/py_trees/devel/LICENSE
+#
+
+##############################################################################
+# Imports
+##############################################################################
+
+import action_msgs.msg as action_msgs  # GoalStatus
+import py_trees
+import py_trees_ros
+import py_trees.console as console
+import rclpy
+import rclpy.executors
+import time
+import unittest
+
+##############################################################################
+# Helpers
+##############################################################################
+
+
+def assert_banner():
+    print(console.green + "----- Asserts -----" + console.reset)
+
+
+def assert_details(text, expected, result):
+    print(console.green + text +
+          "." * (40 - len(text)) +
+          console.cyan + "{}".format(expected) +
+          console.yellow + " [{}]".format(result) +
+          console.reset)
+
+##############################################################################
+# Tests
+##############################################################################
+
+
+class TestActionServers(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        console.banner("ROS Init")
+        rclpy.init()
+        cls.server = py_trees_ros.mock.dock.Dock(duration=0.5)
+
+        cls.timeout = 3.0
+        cls.blackboard = py_trees.blackboard.Blackboard()
+
+    @classmethod
+    def tearDownClass(cls):
+        console.banner("ROS Shutdown")
+        cls.server.shutdown()
+        rclpy.shutdown()
+
+    def setUp(self):
+        pass
+
+##############################################################################
+# Success
+##############################################################################
+
+    def generic_success_test(
+            self,
+            title
+         ):
+        console.banner(title)
+
+        root = py_trees_ros.actions.ActionClient(name="foo")
+        root.setup()
+
+        executor = rclpy.executors.MultiThreadedExecutor(num_threads=4)
+        executor.add_node(self.server.node)
+        # executor.add_node(client.node)
+
+        root.tick_once()
+
+        assert_banner()
+        assert_details("root.status", "RUNNING", root.status)
+
+        executor.shutdown()
+        # client.shutdown()
+
+    def test_client_success(self):
+        self.generic_success_test(title="Client Success")
+
+##############################################################################
+# Preemption
+##############################################################################
+
+##############################################################################
+# Cancel
+##############################################################################
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
With a test. 

There is a bug with the action client though - if you send a cancel request and then call `action_client.destroy()` before the result is returned, you'll segfault. 

I have a hack in place to make sure it waits for the result in the test. I need to make a reproducible example and send upstream.