### PR TITLE
[infra] __init__.py in tests

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -40,6 +40,7 @@
   <doc_depend>unique_id</doc_depend>
   <doc_depend>unique_identifier_msgs</doc_depend>
   -->
+
   <doc_depend>python3-sphinx</doc_depend>
   <doc_depend>python3-sphinx-argparse</doc_depend>
   <doc_depend>python3-sphinx-rtd-theme</doc_depend>
@@ -48,18 +49,12 @@
   <depend>py_trees</depend>
   <depend>py_trees_ros_interfaces</depend>
   <depend>rclpy</depend>
+  <depend>ros2topic</depend>
   <depend>std_msgs</depend>
   <depend>unique_identifier_msgs</depend>
 
   <!-- behaviour dependencies -->
   <depend>sensor_msgs</depend>
-
-  <!--
-  <test_depend>py_trees</test_depend>
-  <test_depend>geometry_msgs</test_depend>
-  <test_depend>rostest</test_depend>
-  <test_depend>rosunit</test_depend>
-  -->
 
   <export>
     <build_type>ament_python</build_type>

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,7 +4,7 @@ Make sure you source the environment to run tests.
 
 ## Executing Tests
 
-```
+```bash
 # run all tests will full stdout
 $ python3 -m unittest discover
 # run a single test


### PR DESCRIPTION
Otherwise you'll get a NotImplementedError when calling
python3 setup.py test.

```
06:35:41 I: pybuild base:217: python3.6 setup.py test 
06:35:41 running test
06:35:41 running egg_info
06:35:41 creating py_trees_ros.egg-info
06:35:41 writing py_trees_ros.egg-info/PKG-INFO
06:35:41 writing dependency_links to py_trees_ros.egg-info/dependency_links.txt
06:35:41 writing entry points to py_trees_ros.egg-info/entry_points.txt
06:35:41 writing top-level names to py_trees_ros.egg-info/top_level.txt
06:35:41 writing manifest file 'py_trees_ros.egg-info/SOURCES.txt'
06:35:41 reading manifest file 'py_trees_ros.egg-info/SOURCES.txt'
06:35:41 writing manifest file 'py_trees_ros.egg-info/SOURCES.txt'
06:35:41 running build_ext
06:35:41 Traceback (most recent call last):
06:35:41   File "setup.py", line 50, in <module>
06:35:41     'py-trees-tree-watcher = py_trees_ros.programs.tree_watcher:main',
06:35:41   File "/usr/lib/python3/dist-packages/setuptools/__init__.py", line 129, in setup
06:35:41     return distutils.core.setup(**attrs)
06:35:41   File "/usr/lib/python3.6/distutils/core.py", line 148, in setup
06:35:41     dist.run_commands()
06:35:41   File "/usr/lib/python3.6/distutils/dist.py", line 955, in run_commands
06:35:41     self.run_command(cmd)
06:35:41   File "/usr/lib/python3.6/distutils/dist.py", line 974, in run_command
06:35:41     cmd_obj.run()
06:35:41   File "/usr/lib/python3/dist-packages/setuptools/command/test.py", line 226, in run
06:35:41     self.run_tests()
06:35:41   File "/usr/lib/python3/dist-packages/setuptools/command/test.py", line 248, in run_tests
06:35:41     exit=False,
06:35:41   File "/usr/lib/python3.6/unittest/main.py", line 94, in __init__
06:35:41     self.parseArgs(argv)
06:35:41   File "/usr/lib/python3.6/unittest/main.py", line 141, in parseArgs
06:35:41     self.createTests()
06:35:41   File "/usr/lib/python3.6/unittest/main.py", line 148, in createTests
06:35:41     self.module)
06:35:41   File "/usr/lib/python3.6/unittest/loader.py", line 219, in loadTestsFromNames
06:35:41     suites = [self.loadTestsFromName(name, module) for name in names]
06:35:41   File "/usr/lib/python3.6/unittest/loader.py", line 219, in <listcomp>
06:35:41     suites = [self.loadTestsFromName(name, module) for name in names]
06:35:41   File "/usr/lib/python3.6/unittest/loader.py", line 190, in loadTestsFromName
06:35:41     return self.loadTestsFromModule(obj)
06:35:41   File "/usr/lib/python3/dist-packages/setuptools/command/test.py", line 44, in loadTestsFromModule
06:35:41     for file in resource_listdir(module.__name__, ''):
06:35:41   File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 1155, in resource_listdir
06:35:41     resource_name
06:35:41   File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 1417, in resource_listdir
06:35:41     return self._listdir(self._fn(self.module_path, resource_name))
06:35:41   File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 1459, in _listdir
06:35:41     "Can't perform this operation for unregistered loader type"
06:35:41 NotImplementedError: Can't perform this operation for unregistered loader type
```