### PR TITLE
[utilities] a more flexible find_topic

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 Forthcoming
 -----------
-* ...
+* [utilities] permit discovery of multiples with find_topics, `#94 <https://github.com/splintered-reality/py_trees_ros/pull/97>`_
 
 1.1.1 (2019-06-22)
 ------------------

--- a/py_trees_ros/trees.py
+++ b/py_trees_ros/trees.py
@@ -380,8 +380,7 @@ class Watcher(object):
     def __init__(
             self,
             namespace_hint: str,
-            mode: WatcherMode=WatcherMode.STREAM
-         ):
+            mode: WatcherMode=WatcherMode.STREAM):
         self.namespace_hint = namespace_hint
         self.subscribers = None
         self.viewing_mode = mode
@@ -407,19 +406,22 @@ class Watcher(object):
             return False
         # taking advantage of there being only one publisher per message
         # type in the namespace to do auto-discovery of names
-        topic_names = {}
-        for key, topic_type_string in [
-            ('snapshots', 'py_trees_ros_interfaces/msg/BehaviourTree')
-        ]:
-            topic_names[key] = utilities.find_topic(
-                self.node,
-                topic_type_string,
-                self.namespace_hint
-            )
+        topic_type_string = 'py_trees_ros_interfaces/msg/BehaviourTree'
+        topic_names = utilities.find_topics(
+            self.node,
+            topic_type_string,
+            self.namespace_hint
+        )
+        if not topic_names:
+            raise exceptions.NotFoundError("topic not found [type: {}]".format(topic_type_string))
+        elif len(topic_names) > 1:
+            raise exceptions.MultipleFoundError("multiple topics found, use a namespace hint [type: {}]".format(topic_type_string))
+        else:
+            topic_name = topic_names[0]
         self.subscribers = utilities.Subscribers(
             node=self.node,
             subscriber_details=[
-                ("snapshots", topic_names["snapshots"], py_trees_msgs.BehaviourTree, True, self.callback_snapshot),
+                ("snapshots", topic_name, py_trees_msgs.BehaviourTree, True, self.callback_snapshot),
             ]
         )
 

--- a/py_trees_ros/utilities.py
+++ b/py_trees_ros/utilities.py
@@ -25,6 +25,7 @@ import rclpy
 import rclpy.node
 import rclpy.qos
 import time
+import typing
 
 from . import exceptions
 
@@ -48,7 +49,7 @@ def find_service(node: rclpy.node.Node,
         timeout: immediately post node creation, can take time to discover the graph (sec)
 
     Returns:
-        :obj:`str`: fully expanded the service name
+        :obj:`str`: fully expanded service name
 
     Raises:
         :class:`~py_trees_ros.exceptions.NotFoundError`: if no services were found
@@ -81,12 +82,11 @@ def find_service(node: rclpy.node.Node,
         raise exceptions.MultipleFoundError("multiple services found [type: {}]".format(service_type))
 
 
-def find_topic(
+def find_topics(
         node: rclpy.node.Node,
         topic_type: str,
         namespace: str=None,
-        timeout: float=0.5
-        ):
+        timeout: float=0.5) -> typing.List[str]:
     """
     Discover a topic of the specified type and if necessary, under the specified
     namespace.
@@ -98,11 +98,7 @@ def find_topic(
         timeout: immediately post node creation, can take time to discover the graph (sec)
 
     Returns:
-        :obj:`str`: fully expanded the service name
-
-    Raises:
-        :class:`~py_trees_ros.exceptions.NotFoundError`: if no services were found
-        :class:`~py_trees_ros.exceptions.MultipleFoundError`: if multiple services were found
+        list of fully expanded topic names (can be empty)
     """
     # TODO: follow the pattern of ros2cli to create a node without the need to init
     # rcl (might get rid of the magic sleep this way). See:
@@ -121,13 +117,7 @@ def find_topic(
         if topic_names:
             break
         time.sleep(loop_period)
-
-    if not topic_names:
-        raise exceptions.NotFoundError("topic not found [type: {}]".format(topic_type))
-    elif len(topic_names) == 1:
-        return topic_names[0]
-    else:
-        raise exceptions.MultipleFoundError("multiple topics found [type: {}]".format(topic_type))
+    return topic_names
 
 
 def basename(name):

--- a/py_trees_ros/utilities.py
+++ b/py_trees_ros/utilities.py
@@ -95,7 +95,9 @@ def find_topics(
         node: nodes have the discovery methods
         topic_type: primary lookup hint
         namespace: secondary lookup hint
-        timeout: immediately post node creation, can take time to discover the graph (sec)
+        timeout: check every 0.1s until this timeout is reached (can be None -> checks once)
+
+    .. note: Immediately post node creation, it can take some time to discover the graph.
 
     Returns:
         list of fully expanded topic names (can be empty)
@@ -108,7 +110,7 @@ def find_topics(
     clock = rclpy.clock.Clock()
     start_time = clock.now()
     topic_names = []
-    while clock.now() - start_time < rclpy.time.Duration(seconds=timeout):
+    while True:
         # Returns a list of the form: [('exchange/blackboard', ['std_msgs/String'])
         topic_names_and_types = node.get_topic_names_and_types()
         topic_names = [name for name, types in topic_names_and_types if topic_type in types]
@@ -116,7 +118,10 @@ def find_topics(
             topic_names = [name for name in topic_names if namespace in name]
         if topic_names:
             break
-        time.sleep(loop_period)
+        if timeout is None or (clock.now() - start_time) > rclpy.time.Duration(seconds=timeout):
+            break
+        else:
+            time.sleep(loop_period)
     return topic_names
 
 


### PR DESCRIPTION
Introduces extra boiler plate on the outside if you're interested
in finding just one topic (can introduce a convenience find_topic
instead of find_topics later if that's a nuisance) but at least
now doesn't block users that want to discover the complete list of
available topics.