### PR TITLE
[subscribers] stricter arg handling

### DIFF
--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -15,4 +15,5 @@ encoding//py_trees_ros/subscribers.py=utf-8
 encoding//py_trees_ros/trees.py=utf-8
 encoding//py_trees_ros/utilities.py=utf-8
 encoding//tests/test_action_client.py=utf-8
+encoding//tests/test_subscribers.py=utf-8
 encoding/setup.py=utf-8

--- a/py_trees_ros/battery.py
+++ b/py_trees_ros/battery.py
@@ -17,6 +17,7 @@ Getting the most out of your battery.
 ##############################################################################
 
 import py_trees
+import rclpy.qos
 import sensor_msgs.msg as sensor_msgs
 
 from . import subscribers
@@ -41,17 +42,20 @@ class ToBlackboard(subscribers.ToBlackboard):
         * battery_low_warning (:obj:`bool`)[w]: False if battery is ok, True if critically low
 
     Args:
-        name: name of the behaviour
         topic_name: name of the battery state topic
+        qos_profile: qos profile for the subscriber
+        name: name of the behaviour
         threshold: percentage level threshold for flagging as low (0-100)
     """
     def __init__(self,
+                 topic_name: str,
+                 qos_profile: rclpy.qos.QoSProfile,
                  name: str=py_trees.common.Name.AUTO_GENERATED,
-                 topic_name: str="/battery/state",
                  threshold: float=30.0):
         super().__init__(name=name,
                          topic_name=topic_name,
                          topic_type=sensor_msgs.BatteryState,
+                         qos_profile=qos_profile,
                          blackboard_variables={"battery": None},
                          clearing_policy=py_trees.common.ClearingPolicy.NEVER
                          )

--- a/py_trees_ros/blackboard.py
+++ b/py_trees_ros/blackboard.py
@@ -67,7 +67,7 @@ class BlackboardView(object):
         self.publisher = self.node.create_publisher(
             msg_type=std_msgs.String,
             topic=topic_name,
-            qos_profile=utilities.qos_profile_latched_topic()
+            qos_profile=utilities.qos_profile_latched()
         )
 
     def shutdown(self):
@@ -220,7 +220,7 @@ class Exchange(object):
         self.publisher = self.node.create_publisher(
             msg_type=std_msgs.String,
             topic='~/exchange/blackboard',
-            qos_profile=utilities.qos_profile_latched_topic()
+            qos_profile=utilities.qos_profile_latched()
         )
         for name in ["get_blackboard_variables",
                      "open_blackboard_watcher",

--- a/py_trees_ros/programs/blackboard_watcher.py
+++ b/py_trees_ros/programs/blackboard_watcher.py
@@ -167,7 +167,7 @@ def main(command_line_args=sys.argv[1:]):
                 msg_type=std_msgs.String,
                 topic=watcher_topic_name,
                 callback=blackboard_watcher.echo_blackboard_contents,
-                qos_profile=rclpy.qos.qos_profile_system_default
+                qos_profile=py_trees_ros.utilities.qos_profile_unlatched()
             )
             # stream
             try:

--- a/py_trees_ros/programs/echo.py
+++ b/py_trees_ros/programs/echo.py
@@ -130,7 +130,7 @@ def create_subscription(node, latched, topic_name, message_type, callback):
             raise RuntimeError('Could not determine the type for the passed topic')
 
     msg_module = ros2topic.api.import_message_type(topic_name, message_type)
-    qos_profile = py_trees_ros.utilities.qos_profile_latched_topic() if latched else rclpy.qos.qos_profile_default
+    qos_profile = py_trees_ros.utilities.qos_profile_latched() if latched else py_trees_ros.utilities.qos_profile_unlatched()
     return node.create_subscription(
         msg_module,
         topic_name,

--- a/py_trees_ros/subscribers.py
+++ b/py_trees_ros/subscribers.py
@@ -88,7 +88,7 @@ class Handler(py_trees.behaviour.Behaviour):
                  name: str=py_trees.common.Name.AUTO_GENERATED,
                  clearing_policy: py_trees.common.ClearingPolicy=py_trees.common.ClearingPolicy.ON_INITIALISE
                  ):
-        super(Handler, self).__init__(name)
+        super(Handler, self).__init__(name=name)
         self.topic_name = topic_name
         self.topic_type = topic_type
         self.msg = None
@@ -194,7 +194,7 @@ class CheckData(Handler):
                  clearing_policy=py_trees.common.ClearingPolicy.ON_INITIALISE
                  ):
         super(CheckData, self).__init__(
-            name,
+            name=name,
             topic_name=topic_name,
             topic_type=topic_type,
             qos_profile=qos_profile,
@@ -292,7 +292,7 @@ class WaitForData(Handler):
                  clearing_policy=py_trees.common.ClearingPolicy.ON_INITIALISE
                  ):
         super().__init__(
-            name,
+            name=name,
             topic_name=topic_name,
             topic_type=topic_type,
             qos_profile=qos_profile,
@@ -370,7 +370,7 @@ class ToBlackboard(Handler):
                  clearing_policy=py_trees.common.ClearingPolicy.ON_INITIALISE
                  ):
         super().__init__(
-            name,
+            name=name,
             topic_name=topic_name,
             topic_type=topic_type,
             qos_profile=qos_profile,

--- a/py_trees_ros/subscribers.py
+++ b/py_trees_ros/subscribers.py
@@ -27,10 +27,12 @@ permitted to be used or written to the blackboard.
 
 import copy
 import operator
+import threading
+import typing
+
 import py_trees
 import rclpy.qos
 import std_msgs.msg as std_msgs
-import threading
 
 from . import utilities
 
@@ -73,18 +75,18 @@ class Handler(py_trees.behaviour.Behaviour):
     some data (e.g. CameraInfo).
 
     Args:
-        name (:obj:`str`): name of the behaviour
-        topic_name (:obj:`str`): name of the topic to connect to
-        topic_type (:obj:`any`): class of the message type (e.g. :obj:`std_msgs.msg.String`)
-        qos_profile (:obj:`bool`): qos profile for the subscriber
-        clearing_policy (:class:`~py_trees.common.ClearingPolicy`): when to clear the data
+        topic_name: name of the topic to connect to
+        topic_type: class of the message type (e.g. :obj:`std_msgs.msg.String`)
+        qos_profile: qos profile for the subscriber
+        name: name of the behaviour
+        clearing_policy: when to clear the data
     """
     def __init__(self,
-                 name="Subscriber Handler",
-                 topic_name="/foo",
-                 topic_type=None,
-                 qos_profile=rclpy.qos.qos_profile_system_default,
-                 clearing_policy=py_trees.common.ClearingPolicy.ON_INITIALISE
+                 topic_name: str,
+                 topic_type: typing.Any,
+                 qos_profile: rclpy.qos.QoSProfile,
+                 name: str=py_trees.common.Name.AUTO_GENERATED,
+                 clearing_policy: py_trees.common.ClearingPolicy=py_trees.common.ClearingPolicy.ON_INITIALISE
                  ):
         super(Handler, self).__init__(name)
         self.topic_name = topic_name
@@ -160,16 +162,16 @@ class CheckData(Handler):
     - fail_if_bad_comparison=True
 
     Args:
-        name (:obj:`str`): name of the behaviour
-        topic_name (:obj:`str`): name of the topic to connect to
-        topic_type (:obj:`any`): class of the message type (e.g. :obj:`std_msgs.msg.String`)
-        qos_profile (:obj:`bool`): qos profile for the subscriber
-        variable_name (:obj:`str`): name of the variable to check
-        expected_value (:obj:`any`): expected value of the variable
-        fail_if_no_data (:obj:`bool`): :attr:`~py_trees.common.Status.FAILURE` instead of :attr:`~py_trees.common.Status.RUNNING` if there is no data yet
-        fail_if_bad_comparison (:obj:`bool`): :attr:`~py_trees.common.Status.FAILURE` instead of :attr:`~py_trees.common.Status.RUNNING` if comparison failed
-        comparison_operator (:obj:`func`): one from the python `operator module`_
-        clearing_policy (:class:`~py_trees.common.ClearingPolicy`): when to clear the data
+        topic_name: name of the topic to connect to
+        topic_type: class of the message type (e.g. :obj:`std_msgs.msg.String`)
+        qos_profile: qos profile for the subscriber
+        variable_name: name of the variable to check
+        expected_value: expected value of the variable
+        comparison_operator: one from the python `operator module`_
+        fail_if_no_data: :attr:`~py_trees.common.Status.FAILURE` instead of :attr:`~py_trees.common.Status.RUNNING` if there is no data yet
+        fail_if_bad_comparison: :attr:`~py_trees.common.Status.FAILURE` instead of :attr:`~py_trees.common.Status.RUNNING` if comparison failed
+        name: name of the behaviour
+        clearing_policy: when to clear the data
 
     .. tip::
 
@@ -180,15 +182,15 @@ class CheckData(Handler):
 
     """
     def __init__(self,
-                 name="Check Data",
-                 topic_name="/foo",
-                 topic_type=None,
-                 qos_profile=utilities.qos_profile_latched_topic(),
-                 variable_name="bar",
-                 expected_value=None,
+                 topic_name: str,
+                 topic_type: typing.Any,
+                 qos_profile: rclpy.qos.QoSProfile,
+                 variable_name: str,
+                 expected_value: typing.Any,
+                 comparison_operator=operator.eq,
                  fail_if_no_data=False,
                  fail_if_bad_comparison=False,
-                 comparison_operator=operator.eq,
+                 name=py_trees.common.Name.AUTO_GENERATED,
                  clearing_policy=py_trees.common.ClearingPolicy.ON_INITIALISE
                  ):
         super(CheckData, self).__init__(
@@ -276,17 +278,17 @@ class WaitForData(Handler):
     which we do with to reset (and subsequently look for the next event). e.g. button events.
 
     Args:
-        name (:obj:`str`): name of the behaviour
-        topic_name (:obj:`str`): name of the topic to connect to
-        topic_type (:obj:`any`): class of the message type (e.g. :obj:`std_msgs.msg.String`)
-        qos_profile (:obj:`bool`): qos profile for the subscriber
-        clearing_policy (:class:`~py_trees.common.ClearingPolicy`): when to clear the data
+        topic_name: name of the topic to connect to
+        topic_type: class of the message type (e.g. :obj:`std_msgs.msg.String`)
+        qos_profile: qos profile for the subscriber
+        name: name of the behaviour
+        clearing_policy: when to clear the data
     """
     def __init__(self,
-                 name="Wait For Data",
-                 topic_name="chatter",
-                 topic_type=None,
-                 qos_profile=utilities.qos_profile_latched_topic(),
+                 topic_name: str,
+                 topic_type: typing.Any,
+                 qos_profile: rclpy.qos.QoSProfile,
+                 name=py_trees.common.Name.AUTO_GENERATED,
                  clearing_policy=py_trees.common.ClearingPolicy.ON_INITIALISE
                  ):
         super().__init__(
@@ -324,13 +326,13 @@ class ToBlackboard(Handler):
     designated, in which case they will write to the specified keys.
 
     Args:
-        name (:obj:`str`): name of the behaviour
-        topic_name (:obj:`str`): name of the topic to connect to
-        topic_type (:obj:`any`): class of the message type (e.g. :obj:`std_msgs.msg.String`)
-        qos_profile (:obj:`bool`): qos profile for the subscriber
-        blackboard_variables (:obj:`dict`): blackboard variable string or dict {names (keys) - message subfields (values)}, use a value of None to indicate the entire message
-        initialise_variables (:obj:`bool`): initialise the blackboard variables to some defaults
-        clearing_policy (:class:`~py_trees.common.ClearingPolicy`): when to clear the data
+        topic_name: name of the topic to connect to
+        topic_type: class of the message type (e.g. :obj:`std_msgs.msg.String`)
+        qos_profile: qos profile for the subscriber
+        blackboard_variables: blackboard variable string or dict {names (keys) - message subfields (values)}, use a value of None to indicate the entire message
+        initialise_variables: initialise the blackboard variables to some defaults
+        name: name of the behaviour
+        clearing_policy: when to clear the data
 
     Examples:
 
@@ -359,12 +361,12 @@ class ToBlackboard(Handler):
            blackboard_variables={"pose_with_covariance_stamped": None, "pose": "pose.pose"}
     """
     def __init__(self,
-                 name="ToBlackboard",
-                 topic_name="chatter",
-                 topic_type=None,
-                 qos_profile=utilities.qos_profile_latched_topic(),
-                 blackboard_variables={"chatter": None},
-                 initialise_variables={},
+                 topic_name: str,
+                 topic_type: typing.Any,
+                 qos_profile: rclpy.qos.QoSProfile,
+                 blackboard_variables: typing.Dict[str, typing.Any]={},  # e.g. {"chatter": None}
+                 initialise_variables: typing.Dict[str, typing.Any]={},
+                 name=py_trees.common.Name.AUTO_GENERATED,
                  clearing_policy=py_trees.common.ClearingPolicy.ON_INITIALISE
                  ):
         super().__init__(
@@ -439,16 +441,16 @@ class EventToBlackboard(Handler):
         tree can utilise the variables.
 
     Args:
-        name (:obj:`str`): name of the behaviour
-        topic_name (:obj:`str`): name of the topic to connect to
-        qos_profile (:obj:`bool`): qos profile for the subscriber
-        variable_name (:obj:`str`): name to write the boolean result on the blackboard
+        topic_name: name of the topic to connect to
+        qos_profile: qos profile for the subscriber
+        variable_name: name to write the boolean result on the blackboard
+        name: name of the behaviour
     """
     def __init__(self,
-                 name="Event to Blackboard",
-                 topic_name="/event",
-                 qos_profile=utilities.qos_profile_latched_topic(),
-                 variable_name="event"
+                 topic_name: str,
+                 qos_profile: rclpy.qos.QoSProfile,
+                 variable_name: str,
+                 name=py_trees.common.Name.AUTO_GENERATED,
                  ):
         super().__init__(
             name=name,

--- a/py_trees_ros/utilities.py
+++ b/py_trees_ros/utilities.py
@@ -156,7 +156,7 @@ def get_py_trees_home():
     return home
 
 
-def qos_profile_latched_topic():
+def qos_profile_latched():
     """
     Convenience retrieval for a latched topic (publisher / subscriber)
     """
@@ -164,6 +164,18 @@ def qos_profile_latched_topic():
         history=rclpy.qos.QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
         depth=1,
         durability=rclpy.qos.QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL,
+        reliability=rclpy.qos.QoSReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_RELIABLE
+    )
+
+
+def qos_profile_unlatched():
+    """
+    Default profile for an unlatched topic (in py_trees_ros).
+    """
+    return rclpy.qos.QoSProfile(
+        history=rclpy.qos.QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
+        depth=1,
+        durability=rclpy.qos.QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_VOLATILE,
         reliability=rclpy.qos.QoSReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_RELIABLE
     )
 
@@ -232,13 +244,13 @@ class Publishers(object):
                 self.__dict__[name] = node.create_publisher(
                     msg_type=publisher_type,
                     topic=topic_name,
-                    qos_profile=qos_profile_latched_topic()
+                    qos_profile=qos_profile_latched()
                 )
             else:
                 self.__dict__[name] = node.create_publisher(
                     msg_type=publisher_type,
                     topic=topic_name,
-                    qos_profile=rclpy.qos.qos_profile_system_default
+                    qos_profile=qos_profile_unlatched()
                 )
             resolved_name = resolve_name(node, topic_name)
             message_type = publisher_type.__class__.__module__.split('.')[0] + "/" + publisher_type.__class__.__name__
@@ -292,14 +304,14 @@ class Subscribers(object):
                     msg_type=subscriber_type,
                     topic=topic_name,
                     callback=callback,
-                    qos_profile=qos_profile_latched_topic()
+                    qos_profile=qos_profile_latched()
                 )
             else:
                 self.__dict__[name] = node.create_subscription(
                     msg_type=subscriber_type,
                     topic=topic_name,
                     callback=callback,
-                    qos_profile=rclpy.qos.qos_profile_system_default
+                    qos_profile=qos_profile_unlatched()
                 )
 
             resolved_name = resolve_name(node, topic_name)

--- a/tests/test_subscribers.py
+++ b/tests/test_subscribers.py
@@ -71,7 +71,7 @@ class TestActionServers(unittest.TestCase):
 
         cls.timeout = 3.0
         cls.number_of_iterations = 100
-        cls.qos_profile = rclpy.qos.qos_profile_sensor_data
+        cls.qos_profile = py_trees_ros.utilities.qos_profile_unlatched()
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_subscribers.py
+++ b/tests/test_subscribers.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# License: BSD
+#   https://raw.githubusercontent.com/splintered-reality/py_trees/devel/LICENSE
+#
+
+##############################################################################
+# Imports
+##############################################################################
+
+import py_trees
+import py_trees.console as console
+import py_trees_ros
+import rclpy
+import rclpy.executors
+import std_msgs.msg as std_msgs
+import unittest
+
+##############################################################################
+# Helpers
+##############################################################################
+
+
+def assert_banner():
+    print(console.green + "----- Asserts -----" + console.reset)
+
+
+def assert_details(text, expected, result):
+    print(console.green + text +
+          "." * (40 - len(text)) +
+          console.cyan + "{}".format(expected) +
+          console.yellow + " [{}]".format(result) +
+          console.reset)
+
+
+class EmptyPublisher(object):
+    def __init__(self, node_name, qos_profile):
+
+        self.node = rclpy.create_node(node_name)
+        self._publisher = self.node.create_publisher(
+            msg_type=std_msgs.Empty,
+            topic="~/empty",
+            qos_profile=qos_profile
+        )
+        self.timer = self.node.create_timer(
+            timer_period_sec=0.1,
+            callback=self.publish
+        )
+
+    def publish(self):
+        self._publisher.publish(std_msgs.Empty())
+
+    def shutdown(self):
+        self._publisher.destroy()
+        self.timer.cancel()
+        self.node.destroy_timer(self.timer)
+        self.node.destroy_node()
+
+##############################################################################
+# Tests
+##############################################################################
+
+
+class TestActionServers(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        console.banner("ROS Init")
+        rclpy.init()
+
+        cls.timeout = 3.0
+        cls.number_of_iterations = 100
+        cls.qos_profile = rclpy.qos.qos_profile_sensor_data
+
+    @classmethod
+    def tearDownClass(cls):
+        console.banner("ROS Shutdown")
+        rclpy.shutdown()
+
+    def setUp(self):
+        pass
+
+    ########################################
+    # Wait for Data
+    ########################################
+
+    def test_wait_for_data(self):
+        console.banner("Wait for Data")
+
+        publisher = EmptyPublisher(node_name="wait_for_data", qos_profile=self.qos_profile)
+        root = py_trees_ros.subscribers.WaitForData(
+            topic_name="/wait_for_data/empty",
+            topic_type=std_msgs.Empty,
+            qos_profile=self.qos_profile
+        )
+        tree = py_trees_ros.trees.BehaviourTree(root=root, unicode_tree_debug=False)
+        tree.setup()
+
+        executor = rclpy.executors.MultiThreadedExecutor(num_threads=4)
+        executor.add_node(publisher.node)
+        executor.add_node(tree.node)
+
+        assert_banner()
+
+        tree.tick_tock(
+            period_ms=100,
+            number_of_iterations=self.number_of_iterations
+        )
+
+        while tree.count < self.number_of_iterations and root.status != py_trees.common.Status.SUCCESS:
+            executor.spin_once(timeout_sec=0.05)
+
+        assert_details("root.status", "SUCCESS", root.status)
+        self.assertEqual(root.status, py_trees.common.Status.SUCCESS)
+
+        tree.shutdown()
+        publisher.shutdown()
+        executor.shutdown()
+
+
+##############################################################################
+# Main
+##############################################################################
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Require users to provide, especially, ros comms arguments given that
there are more things that can go wrong in ros2 by blindly setting
best effort guesses.

* Resolves #102.
* Adds the first subscriber behaviour test
* Convenience method for unlatched reliable profiles in demos/test

FYI @peterpena
