### PR TITLE
Publish snapshot changed & key access info

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 Forthcoming
 -----------
-* ...
+* [trees] snapshot publishing changed, key access info, `#124 <https://github.com/splintered-reality/py_trees_ros/pull/124>`_,
 
 2.0.0 (2019-11-20)
 ------------------

--- a/py_trees_ros/conversions.py
+++ b/py_trees_ros/conversions.py
@@ -240,7 +240,26 @@ def behaviour_to_msg(behaviour: py_trees.behaviour.Behaviour) -> py_trees_ros_in
     msg.blackbox_level = blackbox_enum_to_msg_constant(behaviour.blackbox_level)
     msg.status = status_enum_to_msg_constant(behaviour.status)
     msg.message = behaviour.feedback_message
-
+    msg.blackboard_access = []
+    for blackboard in behaviour.blackboards:
+        for key in blackboard.read:
+            access_info = py_trees_ros_interfaces.msg.KeyValue(
+                key=key,
+                value=py_trees_ros_interfaces.msg.Behaviour.BLACKBOARD_ACCESS_READ  # noqa
+            )
+            msg.blackboard_access.append(access_info)
+        for key in blackboard.write:
+            access_info = py_trees_ros_interfaces.msg.KeyValue(
+                key=key,
+                value=py_trees_ros_interfaces.msg.Behaviour.BLACKBOARD_ACCESS_WRITE  # noqa
+            )
+            msg.blackboard_access.append(access_info)
+        for key in blackboard.exclusive:
+            access_info = py_trees_ros_interfaces.msg.KeyValue(
+                key=key,
+                value=py_trees_ros_interfaces.msg.Behaviour.BLACKBOARD_ACCESS_EXCLUSIVE_WRITE  # noqa
+            )
+            msg.blackboard_access.append(access_info)
     return msg
 
 


### PR DESCRIPTION
No breaking api changes, just additional information in the snapshot in preparation for getting key info into the viewer and permitting periodic snapshots even when the tree status or graph hasn't changed.