### PR TITLE
[trees] avoid irregular snapshot streams by avoiding timing jitter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 Forthcoming
 -----------
-* ...
+* [trees] avoid irregular snapshot streams by avoiding timing jitter, `#151 <https://github.com/splintered-reality/py_trees_ros/pull/151>`_
 
 2.0.7 (2020-02-10)
 ------------------

--- a/py_trees_ros/trees.py
+++ b/py_trees_ros/trees.py
@@ -166,7 +166,8 @@ class SnapshotStream(object):
             self.last_snapshot_timestamp = time.monotonic()
         current_timestamp = time.monotonic()
         elapsed_time = current_timestamp - self.last_snapshot_timestamp
-        if (not changed and elapsed_time < self.parameters.snapshot_period):
+        if_its_close_enough = 0.98  # https://github.com/splintered-reality/py_trees_ros/issues/144
+        if (not changed and elapsed_time < if_its_close_enough * self.parameters.snapshot_period):
             return
 
         tree_message = py_trees_msgs.BehaviourTree()


### PR DESCRIPTION
Resolves #144.