### PR TITLE
Default to periodic checks with warnings for action client timeouts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ Forthcoming
 -----------
 * ...
 
+2.0.9 (2020-03-05)
+------------------
+* [behaviours] default to periodic checks with warnings for action client timeouts, `#153 <https://github.com/splintered-reality/py_trees_ros/pull/153>`_
+
 2.0.8 (2020-03-04)
 ------------------
 * [behaviours] wait_for_server_timeout_sec in action clients, `#152 <https://github.com/splintered-reality/py_trees_ros/pull/152>`_

--- a/tests/test_action_client.py
+++ b/tests/test_action_client.py
@@ -322,7 +322,7 @@ def test_from_blackboard():
 
     py_trees.blackboard.Blackboard.set(
         variable_name="/goal",
-        value=py_trees_actions.Dock.Goal(dock=True)
+        value=py_trees_actions.Dock.Goal(dock=True)  # noqa
     )
 
     tree.tick()


### PR DESCRIPTION
This saves the user having to do any mucking around with timeouts (so long as they are using a behaviour tree manager for the tree setup timeout).