### PR TITLE
Log a one-shot warning instead of exceptions when pickle fails

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+Forthcoming
+-----------
+* ...
+
+0.5.18 (2020-03-23)
+-------------------
+* [blackboards] log a one-shot warning instead of exceptions when pickle fails, `#157 <https://github.com/splintered-reality/py_trees_ros/pull/157>`_
+
 0.5.18 (2019-03-23)
 -------------------
 * [infra] merge kinetic and melodic release branches

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,10 +4,6 @@ Changelog
 
 Forthcoming
 -----------
-* ...
-
-0.5.18 (2020-03-23)
--------------------
 * [blackboards] log a one-shot warning instead of exceptions when pickle fails, `#157 <https://github.com/splintered-reality/py_trees_ros/pull/157>`_
 
 0.5.18 (2019-03-23)

--- a/py_trees_ros/tutorials/two.py
+++ b/py_trees_ros/tutorials/two.py
@@ -95,7 +95,6 @@ import py_trees_ros
 import py_trees.console as console
 import rospy
 import sys
-import threading
 
 ##############################################################################
 # Behaviours
@@ -127,9 +126,6 @@ def create_root():
     topics2bb.add_child(battery2bb)
     priorities.add_children([battery_check, idle])
     battery_check.add_children([is_battery_ok, flash_led_strip])
-    print("Setting Foo")
-    blackboard = py_trees.blackboard.Blackboard()
-    blackboard.set("foo", threading.Lock())
     return root
 
 

--- a/py_trees_ros/tutorials/two.py
+++ b/py_trees_ros/tutorials/two.py
@@ -95,6 +95,7 @@ import py_trees_ros
 import py_trees.console as console
 import rospy
 import sys
+import threading
 
 ##############################################################################
 # Behaviours
@@ -126,6 +127,9 @@ def create_root():
     topics2bb.add_child(battery2bb)
     priorities.add_children([battery_check, idle])
     battery_check.add_children([is_battery_ok, flash_led_strip])
+    print("Setting Foo")
+    blackboard = py_trees.blackboard.Blackboard()
+    blackboard.set("foo", threading.Lock())
     return root
 
 


### PR DESCRIPTION
Workaround for #108 on `melodic`.

See also #156 for `devel`.