### PR TITLE
Add optional node and node name arguments to tree setup

### DIFF
--- a/py_trees_ros/trees.py
+++ b/py_trees_ros/trees.py
@@ -27,6 +27,7 @@ import os
 import math
 import statistics
 import subprocess
+import sys
 import tempfile
 import time
 import typing
@@ -370,7 +371,7 @@ class BehaviourTree(py_trees.trees.BehaviourTree):
                 read_only=False,
                 floating_point_range=[rcl_interfaces_msgs.FloatingPointRange(
                     from_value=0.0,
-                    to_value=py_trees.common.Duration.INFINITE.value)]
+                    to_value=sys.float_info.max)]
             )
         )
 
@@ -418,7 +419,7 @@ class BehaviourTree(py_trees.trees.BehaviourTree):
                 read_only=True,
                 floating_point_range=[rcl_interfaces_msgs.FloatingPointRange(
                     from_value=0.0,
-                    to_value=py_trees.common.Duration.INFINITE.value)]
+                    to_value=sys.float_info.max)]
             )
         )
         # Get the resulting timeout

--- a/py_trees_ros/utilities.py
+++ b/py_trees_ros/utilities.py
@@ -161,10 +161,10 @@ def qos_profile_latched():
     Convenience retrieval for a latched topic (publisher / subscriber)
     """
     return rclpy.qos.QoSProfile(
-        history=rclpy.qos.QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
+        history=rclpy.qos.QoSHistoryPolicy.KEEP_LAST,
         depth=1,
-        durability=rclpy.qos.QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL,
-        reliability=rclpy.qos.QoSReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_RELIABLE
+        durability=rclpy.qos.QoSDurabilityPolicy.TRANSIENT_LOCAL,
+        reliability=rclpy.qos.QoSReliabilityPolicy.RELIABLE
     )
 
 
@@ -173,10 +173,10 @@ def qos_profile_unlatched():
     Default profile for an unlatched topic (in py_trees_ros).
     """
     return rclpy.qos.QoSProfile(
-        history=rclpy.qos.QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
+        history=rclpy.qos.QoSHistoryPolicy.KEEP_LAST,
         depth=1,
-        durability=rclpy.qos.QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_VOLATILE,
-        reliability=rclpy.qos.QoSReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_RELIABLE
+        durability=rclpy.qos.QoSDurabilityPolicy.VOLATILE,
+        reliability=rclpy.qos.QoSReliabilityPolicy.RELIABLE
     )
 
 


### PR DESCRIPTION
This PR aims to address my request in https://github.com/splintered-reality/py_trees_ros/issues/181.

Specifically, I added a few extra arguments to the `setup()` method of `py_trees_ros.trees.BehaviourTree`:

* `node` accepts an existing `rclpy.node.Node` object so instead of always creating a new node, it can accept an existing one.
* `node_name` accepts the name of the node, if one is still created by `setup()`.

This makes it so that I can create a derived class from `Node` that internally creates a behavior tree, and it can declare parameters / get parameter values ahead of the setup stage.