### PR TITLE
Implement Behaviors to Interact with ROS Services

### DIFF
--- a/docs/sources/conf.py
+++ b/docs/sources/conf.py
@@ -146,6 +146,7 @@ MOCK_MODULES = [
     'ros2topic', 'ros2topic.api',
     'sensor_msgs', 'sensor_msgs.msg',
     'std_msgs', 'std_msgs.msg',
+    'std_srvs', 'std_srvs.srv',
     'tf2_ros',
     'unique_identifier_msgs', 'unique_identifier_msgs.msg'
 ]

--- a/package.xml
+++ b/package.xml
@@ -34,6 +34,7 @@
   <depend>rclpy</depend>
   <depend>ros2topic</depend>
   <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
   <depend>unique_identifier_msgs</depend>
 
   <!-- behaviour dependencies (subscribers, transforms, ...) -->

--- a/py_trees_ros/__init__.py
+++ b/py_trees_ros/__init__.py
@@ -23,6 +23,7 @@ from . import exceptions
 from . import mock
 from . import programs
 from . import publishers
+from . import service_clients
 from . import subscribers
 from . import transforms
 from . import trees

--- a/py_trees_ros/action_clients.py
+++ b/py_trees_ros/action_clients.py
@@ -151,7 +151,7 @@ class FromBlackboard(py_trees.behaviour.Behaviour):
             action_name=self.action_name
         )
         result = None
-        if self.wait_for_server_timeout_sec > 0.0:
+        if self.wait_for_server_timeout_sec >= 0.0:
             result = self.action_client.wait_for_server(timeout_sec=self.wait_for_server_timeout_sec)
         else:
             iterations = 0

--- a/py_trees_ros/action_clients.py
+++ b/py_trees_ros/action_clients.py
@@ -58,7 +58,7 @@ class FromBlackboard(py_trees.behaviour.Behaviour):
             name="WaitForGoal",
             variable_name="/my_goal"
         )
-        action_client = py_trees_ros.aciton_clients.FromBlackboard(
+        action_client = py_trees_ros.action_clients.FromBlackboard(
             action_type=py_trees_actions.Dock,
             action_name="dock",
             name="ActionClient"

--- a/py_trees_ros/action_clients.py
+++ b/py_trees_ros/action_clients.py
@@ -151,8 +151,10 @@ class FromBlackboard(py_trees.behaviour.Behaviour):
             action_name=self.action_name
         )
         result = None
-        if self.wait_for_server_timeout_sec >= 0.0:
+        if self.wait_for_server_timeout_sec > 0.0:
             result = self.action_client.wait_for_server(timeout_sec=self.wait_for_server_timeout_sec)
+        elif self.wait_for_server_timeout_sec == 0.0:
+            result = True # don't wait and don't check if the server is ready
         else:
             iterations = 0
             period_sec = -1.0*self.wait_for_server_timeout_sec

--- a/py_trees_ros/mock/__init__.py
+++ b/py_trees_ros/mock/__init__.py
@@ -15,3 +15,5 @@ This package contains mock ROS nodes for py_trees tests.
 
 from . import actions
 from . import dock
+from . import services
+from . import set_bool

--- a/py_trees_ros/mock/services.py
+++ b/py_trees_ros/mock/services.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# License: BSD
+#   https://raw.githubusercontent.com/splintered-reality/py_trees_ros_tutorials/devel/LICENSE
+#
+##############################################################################
+# Documentation
+##############################################################################
+
+"""
+Service server templates.
+"""
+
+##############################################################################
+# Imports
+##############################################################################
+
+import time
+
+import rclpy
+
+##############################################################################
+# Service Server
+##############################################################################
+#
+# References:
+#
+#  service client        : https://github.com/ros2/rclpy/blob/rolling/rclpy/rclpy/client.py
+#  service server        : https://github.com/ros2/rclpy/blob/rolling/rclpy/rclpy/service.py
+#  service examples      : https://github.com/ros2/examples/tree/rolling/rclpy/services
+
+class GenericServer(object):
+    """
+    Generic service server that can be used for testing.
+
+    Args:
+        node_name (:obj:`str`): name of the node
+        service_name (:obj:`str`): name of the service
+        service_type (:obj:`type`): type of the service
+        sleep_time (:obj:`float`): time to sleep before returning a response
+        callback (:obj:`Optional[callable]`): callback to execute when the service is called
+    """
+    def __init__(self,
+                 node_name,
+                 service_name,
+                 service_type,
+                 sleep_time=1.0,
+                 callback=None):
+        self.node = rclpy.create_node(node_name)
+
+        self.sleep_time = sleep_time
+        self.callback = callback
+
+        # Create the service
+        self.server = self.node.create_service(
+            service_type,
+            service_name,
+            self.execute_callback
+        )
+
+    def execute_callback(self, request, response):
+        """
+        Execute the callback and populate the response.
+        """
+        if self.callback is not None:
+            return self.callback(request, response)
+        
+        # Do nothing
+        time.sleep(self.sleep_time)
+        return response
+    
+    def shutdown(self):
+        """
+        Cleanup
+        """
+        self.server.destroy()
+        self.node.destroy_node()

--- a/py_trees_ros/mock/set_bool.py
+++ b/py_trees_ros/mock/set_bool.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# License: BSD
+#   https://raw.githubusercontent.com/splintered-reality/py_trees_ros/devel/LICENSE
+#
+##############################################################################
+# Documentation
+##############################################################################
+
+"""
+Mocks a SetBool service
+"""
+
+
+##############################################################################
+# Imports
+##############################################################################
+
+import time
+
+from std_srvs.srv import SetBool
+
+from . import services
+
+##############################################################################
+# Class
+##############################################################################
+
+
+class SetBoolServer(services.GenericServer):
+    """
+    Simple server that docks if the goal is true, undocks otherwise.
+    """
+    SUCCESS_MESSAGE = "Succeeded in setting bool to True"
+    FAILURE_MESSAGE = "Failed to set bool to False"
+
+    def __init__(self, sleep_time=1.0):
+        super().__init__(
+            node_name="set_bool_server",
+            service_name="set_bool",
+            service_type=SetBool,
+            sleep_time=sleep_time,
+            callback=self.callback,
+        )
+
+    def callback(self, request, response):
+        time.sleep(self.sleep_time)
+        if request.data:
+            response.success = True
+            response.message = SetBoolServer.SUCCESS_MESSAGE
+        else:
+            response.success = False
+            response.message = SetBoolServer.FAILURE_MESSAGE
+        return response

--- a/py_trees_ros/service_clients.py
+++ b/py_trees_ros/service_clients.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# License: BSD
+#   https://raw.github.com/splintered-reality/py_trees_ros/license/LICENSE
+#
+##############################################################################
+# Documentation
+##############################################################################
+
+"""
+Behaviours for ROS services.
+"""
+
+##############################################################################
+# Imports
+##############################################################################
+
+from asyncio.tasks import wait_for
+import typing
+import uuid
+
+import py_trees
+
+from . import exceptions
+
+##############################################################################
+# Behaviours
+##############################################################################
+
+
+class FromBlackboard(py_trees.behaviour.Behaviour):
+    """
+    An service client interface that draws requests from the blackboard. The
+    lifecycle of this behaviour works as follows:
+
+    * :meth:`initialise`: check blackboard for a request and send
+    * :meth:`update`: if a request was sent, monitor progress
+    * :meth:`terminate`: if interrupted while running, send a cancel request
+
+    As a consequence, the status of this behaviour can be interpreted as follows:
+
+    * :data:`~py_trees.common.Status.FAILURE`: no request was found to send,
+      the server was not ready, or it failed while executing
+    * :data:`~py_trees.common.Status.RUNNING`: a request was sent and is still
+      executing
+    * :data:`~py_trees.common.Status.SUCCESS`: sent request has completed with success
+
+    To block on the arrival of a request on the blackboard, use with the
+    :class:`py_trees.behaviours.WaitForBlackboardVariable` behaviour. e.g.
+
+    Args:
+        name: name of the behaviour
+        service_type: spec type for the service
+        service_name: where you can find the service
+        key_request: name of the key for the request on the blackboard
+        key_response: optional name of the key for the response on the blackboard (default: None)
+        wait_for_server_timeout_sec: use negative values for a blocking but periodic check (default: -3.0)
+
+    .. note::
+       The default setting for timeouts (a negative value) will suit
+       most use cases. With this setting the behaviour will periodically check and
+       issue a warning if the server can't be found. Actually aborting the setup can
+       usually be left up to the behaviour tree manager.
+    """
+    def __init__(self,
+                 name: str,
+                 service_type: typing.Any,
+                 service_name: str,
+                 key_request: str,
+                 key_response: typing.Optional[str],
+                 wait_for_server_timeout_sec: float=-3.0
+                 ):
+        super().__init__(name)
+        self.service_type = service_type
+        self.service_name = service_name
+        self.wait_for_server_timeout_sec = wait_for_server_timeout_sec
+        self.blackboard = self.attach_blackboard_client(name=self.name)
+        self.blackboard.register_key(
+            key="request",
+            access=py_trees.common.Access.READ,
+            # make sure to namespace it if not already
+            remap_to=py_trees.blackboard.Blackboard.absolute_name("/", key_request)
+        )
+        self.write_response_to_blackboard = key_response is not None
+        if self.write_response_to_blackboard:
+            self.blackboard.register_key(
+                key="response",
+                access=py_trees.common.Access.WRITE,
+                # make sure to namespace it if not already
+                remap_to=py_trees.blackboard.Blackboard.absolute_name("/", key_response)
+            )
+
+        self.node = None
+        self.service_client = None
+
+    def setup(self, **kwargs):
+        """
+        Setup the service client and ensure it is available.
+
+        Args:
+            **kwargs (:obj:`dict`): distribute arguments to this
+               behaviour and in turn, all of it's children
+
+        Raises:
+            :class:`KeyError`: if a ros2 node isn't passed under the key 'node' in kwargs
+            :class:`~py_trees_ros.exceptions.TimedOutError`: if the service server could not be found
+        """
+        self.logger.debug("{}.setup()".format(self.qualified_name))
+        try:
+            self.node = kwargs['node']
+        except KeyError as e:
+            error_message = "didn't find 'node' in setup's kwargs [{}][{}]".format(self.qualified_name)
+            raise KeyError(error_message) from e  # 'direct cause' traceability
+
+        self.service_client = self.node.create_client(srv_type=self.service_type, srv_name=self.service_name)
+
+        result = None
+        if self.wait_for_server_timeout_sec > 0.0:
+            result = self.service_client.wait_for_service(timeout_sec=self.wait_for_server_timeout_sec)
+        else:
+            iterations = 0
+            period_sec = -1.0*self.wait_for_server_timeout_sec
+            while not result:
+                iterations += 1
+                result = self.service_client.wait_for_service(timeout_sec=period_sec)
+                if not result:
+                    self.node.get_logger().warning(
+                        "waiting for service server ... [{}s][{}][{}]".format(
+                            iterations * period_sec,
+                            self.service_name,
+                            self.qualified_name
+                        )
+                    )
+        if not result:
+            self.feedback_message = "timed out waiting for the server [{}]".format(self.service_name)
+            self.node.get_logger().error("{}[{}]".format(self.feedback_message, self.qualified_name))
+            raise exceptions.TimedOutError(self.feedback_message)
+        else:
+            self.feedback_message = "... connected to service server [{}]".format(self.service_name)
+            self.node.get_logger().info("{}[{}]".format(self.feedback_message, self.qualified_name))
+
+    def initialise(self):
+        """
+        Reset the internal variables and kick off a new request request.
+        """
+        self.logger.debug("{}.initialise()".format(self.qualified_name))
+
+        # initialise some temporary variables
+        self.service_future = None
+
+        try:
+            if self.service_client.service_is_ready():
+                self.service_future = self.service_client.call_async(self.blackboard.request)
+        except (KeyError, TypeError):
+            pass  # self.service_future will be None, check on that
+
+    def update(self):
+        """
+        Check only to see whether the underlying service server has
+        succeeded, is running, or has cancelled/aborted for some reason and
+        map these to the usual behaviour return states.
+
+        Returns:
+            :class:`py_trees.common.Status`
+        """
+        self.logger.debug("{}.update()".format(self.qualified_name))
+
+        if self.service_future is None:
+            # either there was no request on the blackboard, the request's type
+            # was wrong, or the service server wasn't ready
+            return py_trees.common.Status.FAILURE
+        elif not self.service_future.done():
+            # service has been called but hasn't yet returned a result
+            return py_trees.common.Status.RUNNING
+        else:
+            # service has succeeded; get the result
+            self.response = self.service_future.result()
+            if self.write_response_to_blackboard:
+                self.blackboard.response = self.response
+            return py_trees.common.Status.SUCCESS
+        
+    def terminate(self, new_status: py_trees.common.Status):
+        """
+        If running and the current request has not already succeeded, cancel it.
+
+        Args:
+            new_status: the behaviour is transitioning to this new status
+        """
+        self.logger.debug(
+            "{}.terminate({})".format(
+                self.qualified_name,
+                "{}->{}".format(self.status, new_status) if self.status != new_status else "{}".format(new_status)
+            )
+        )
+        if (self.service_future is not None) and (not self.service_future.done()):
+            self.service_client.remove_pending_request(self.service_future)
+
+    def shutdown(self):
+        """
+        Clean up the service client when shutting down.
+        """
+        self.service_client.destroy()
+
+
+class FromConstant(FromBlackboard):
+    """
+    Convenience version of the service client that only ever sends the
+    same goal.
+
+    .. see-also: :class:`py_trees_ros.service_clients.FromBlackboard`
+
+    Args:
+        name: name of the behaviour
+        name: name of the behaviour
+        service_type: spec type for the service
+        service_name: where you can find the service
+        service_request: the request to send
+        key_response: optional name of the key for the response on the blackboard (default: None)
+        wait_for_server_timeout_sec: use negative values for a blocking but periodic check (default: -3.0)
+
+    .. note::
+       The default setting for timeouts (a negative value) will suit
+       most use cases. With this setting the behaviour will periodically check and
+       issue a warning if the server can't be found. Actually aborting the setup can
+       usually be left up to the behaviour tree manager.
+    """
+    def __init__(self,
+                 name: str,
+                 service_type: typing.Any,
+                 service_name: str,
+                 service_request: typing.Any,
+                 key_response: typing.Optional[str]=None,
+                 wait_for_server_timeout_sec: float=-3.0
+                 ):
+        unique_id = uuid.uuid4()
+        key_request = "/goal_" + str(unique_id)
+        super().__init__(
+            service_type=service_type,
+            service_name=service_name,
+            key_request=key_request,
+            key_response=key_response,
+            name=name,
+            wait_for_server_timeout_sec=wait_for_server_timeout_sec
+        )
+        # parent already instantiated a blackboard client
+        self.blackboard.register_key(
+            key=key_request,
+            access=py_trees.common.Access.WRITE,
+        )
+        self.blackboard.set(name=key_request, value=service_request)

--- a/py_trees_ros/service_clients.py
+++ b/py_trees_ros/service_clients.py
@@ -73,7 +73,7 @@ class FromBlackboard(py_trees.behaviour.Behaviour):
                  ):
         super().__init__(name)
         self.service_type = service_type
-        self.service_name = service_name
+        self.init_service_name = service_name
         self.wait_for_server_timeout_sec = wait_for_server_timeout_sec
         self.blackboard = self.attach_blackboard_client(name=self.name)
         self.blackboard.register_key(
@@ -112,6 +112,10 @@ class FromBlackboard(py_trees.behaviour.Behaviour):
         except KeyError as e:
             error_message = "didn't find 'node' in setup's kwargs [{}][{}]".format(self.qualified_name)
             raise KeyError(error_message) from e  # 'direct cause' traceability
+
+        # Handle service name remappings, which are not handled by default in rclpy.
+        # See https://github.com/ros2/rclpy/issues/954
+        self.service_name = self.node.resolve_service_name(self.init_service_name)
 
         self.service_client = self.node.create_client(srv_type=self.service_type, srv_name=self.service_name)
 

--- a/py_trees_ros/service_clients.py
+++ b/py_trees_ros/service_clients.py
@@ -73,7 +73,7 @@ class FromBlackboard(py_trees.behaviour.Behaviour):
                  ):
         super().__init__(name)
         self.service_type = service_type
-        self.init_service_name = service_name
+        self.service_name = service_name
         self.wait_for_server_timeout_sec = wait_for_server_timeout_sec
         self.blackboard = self.attach_blackboard_client(name=self.name)
         self.blackboard.register_key(
@@ -113,10 +113,6 @@ class FromBlackboard(py_trees.behaviour.Behaviour):
             error_message = "didn't find 'node' in setup's kwargs [{}][{}]".format(self.qualified_name)
             raise KeyError(error_message) from e  # 'direct cause' traceability
 
-        # Handle service name remappings, which are not handled by default in rclpy.
-        # See https://github.com/ros2/rclpy/issues/954
-        self.service_name = self.node.resolve_service_name(self.init_service_name)
-
         self.service_client = self.node.create_client(srv_type=self.service_type, srv_name=self.service_name)
 
         result = None
@@ -132,16 +128,20 @@ class FromBlackboard(py_trees.behaviour.Behaviour):
                     self.node.get_logger().warning(
                         "waiting for service server ... [{}s][{}][{}]".format(
                             iterations * period_sec,
-                            self.service_name,
+                            self.node.resolve_service_name(self.service_name),
                             self.qualified_name
                         )
                     )
         if not result:
-            self.feedback_message = "timed out waiting for the server [{}]".format(self.service_name)
+            self.feedback_message = "timed out waiting for the server [{}]".format(
+                self.node.resolve_service_name(self.service_name)
+            )
             self.node.get_logger().error("{}[{}]".format(self.feedback_message, self.qualified_name))
             raise exceptions.TimedOutError(self.feedback_message)
         else:
-            self.feedback_message = "... connected to service server [{}]".format(self.service_name)
+            self.feedback_message = "... connected to service server [{}]".format(
+                self.node.resolve_service_name(self.service_name)
+            )
             self.node.get_logger().info("{}[{}]".format(self.feedback_message, self.qualified_name))
 
     def initialise(self):

--- a/py_trees_ros/service_clients.py
+++ b/py_trees_ros/service_clients.py
@@ -116,8 +116,10 @@ class FromBlackboard(py_trees.behaviour.Behaviour):
         self.service_client = self.node.create_client(srv_type=self.service_type, srv_name=self.service_name)
 
         result = None
-        if self.wait_for_server_timeout_sec >= 0.0:
+        if self.wait_for_server_timeout_sec > 0.0:
             result = self.service_client.wait_for_service(timeout_sec=self.wait_for_server_timeout_sec)
+        elif self.wait_for_server_timeout_sec == 0.0:
+            result = True # don't wait and don't check if the server is ready
         else:
             iterations = 0
             period_sec = -1.0*self.wait_for_server_timeout_sec

--- a/py_trees_ros/service_clients.py
+++ b/py_trees_ros/service_clients.py
@@ -116,7 +116,7 @@ class FromBlackboard(py_trees.behaviour.Behaviour):
         self.service_client = self.node.create_client(srv_type=self.service_type, srv_name=self.service_name)
 
         result = None
-        if self.wait_for_server_timeout_sec > 0.0:
+        if self.wait_for_server_timeout_sec >= 0.0:
             result = self.service_client.wait_for_service(timeout_sec=self.wait_for_server_timeout_sec)
         else:
             iterations = 0

--- a/py_trees_ros/service_clients.py
+++ b/py_trees_ros/service_clients.py
@@ -68,7 +68,7 @@ class FromBlackboard(py_trees.behaviour.Behaviour):
                  service_type: typing.Any,
                  service_name: str,
                  key_request: str,
-                 key_response: typing.Optional[str],
+                 key_response: typing.Optional[str]=None,
                  wait_for_server_timeout_sec: float=-3.0
                  ):
         super().__init__(name)

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,7 +8,7 @@ $ pytest-3
 $ pytest-3 -s
 
 # run a test module
-$ pytest-3 -s test_alakazam.py
+$ pytest-3 -s test_action_client.py
 
 # run a single test
 $ pytest-3 -s test_action_clients.py::test_success

--- a/tests/test_action_client.py
+++ b/tests/test_action_client.py
@@ -332,7 +332,7 @@ def test_from_blackboard():
 
     tree.tick()
 
-    # Nothing on blackboard yet
+    # Goal exists on blackboard
     assert_details("Goal exists - root.status", "RUNNING", root.status)
     assert(root.status == py_trees.common.Status.RUNNING)
 

--- a/tests/test_service_client.py
+++ b/tests/test_service_client.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# License: BSD
+#   https://raw.githubusercontent.com/splintered-reality/py_trees/devel/LICENSE
+#
+
+##############################################################################
+# Imports
+##############################################################################
+
+import py_trees
+import py_trees.console as console
+import py_trees_ros
+from std_srvs.srv import SetBool, Trigger
+import rclpy
+import rclpy.action
+import rclpy.executors
+import time
+
+##############################################################################
+# Helpers
+##############################################################################
+
+
+def assert_banner():
+    print(console.green + "----- Asserts -----" + console.reset)
+
+
+def assert_details(text, expected, result):
+    print(console.green + text +
+          "." * (40 - len(text)) +
+          console.cyan + "{}".format(expected) +
+          console.yellow + " [{}]".format(result) +
+          console.reset)
+
+
+def create_service_client(from_blackboard=False, key_response=None, wait_for_server_timeout_sec=2.0):
+    if from_blackboard:
+        behaviour = py_trees_ros.service_clients.FromBlackboard(
+            name="set_bool_client",
+            service_type=SetBool,
+            service_name="set_bool",
+            key_request="request",
+            key_response=key_response,
+            wait_for_server_timeout_sec=wait_for_server_timeout_sec
+        )
+    else:
+        behaviour = py_trees_ros.service_clients.FromConstant(
+            name="set_bool_client",
+            service_type=SetBool,
+            service_name="set_bool",
+            service_request=SetBool.Request(data=True),
+            key_response=key_response,
+            wait_for_server_timeout_sec=wait_for_server_timeout_sec
+        )
+    return behaviour
+
+
+def print_unicode_tree(tree):
+    print(
+        "\n" +
+        py_trees.display.unicode_tree(
+            tree.root,
+            visited=tree.snapshot_visitor.visited,
+            previously_visited=tree.snapshot_visitor.previously_visited
+        )
+    )
+
+
+def setup_module(module):
+    console.banner("ROS Init")
+    rclpy.init()
+
+
+def teardown_module(module):
+    console.banner("ROS Shutdown")
+    rclpy.shutdown()
+
+
+def timeout():
+    return 3.0
+
+
+def number_of_iterations():
+    return 100
+
+##############################################################################
+# Tests
+##############################################################################
+
+
+########################################
+# Success, From Constant
+########################################
+
+def test_success():
+    console.banner("Client Success")
+
+    server = py_trees_ros.mock.set_bool.SetBoolServer(sleep_time=1.0)
+
+    root = create_service_client()
+    tree = py_trees_ros.trees.BehaviourTree(
+        root=root,
+        unicode_tree_debug=False
+    )
+    tree.setup()
+
+    executor = rclpy.executors.MultiThreadedExecutor(num_threads=4)
+    executor.add_node(server.node)
+    executor.add_node(tree.node)
+
+    assert_banner()
+
+    assert_details("root.status", "INVALID", root.status)
+    assert(root.status == py_trees.common.Status.INVALID)
+
+    tree.tick()
+
+    assert_details("root.status", "RUNNING", root.status)
+    assert(root.status == py_trees.common.Status.RUNNING)
+
+    tree.tick_tock(
+        period_ms=100,
+        number_of_iterations=number_of_iterations()
+    )
+
+    while tree.count < number_of_iterations() and root.status == py_trees.common.Status.RUNNING:
+        executor.spin_once(timeout_sec=0.05)
+
+    assert_details("root.status", "SUCCESS", root.status)
+    assert(root.status == py_trees.common.Status.SUCCESS)
+
+    tree.shutdown()
+    server.shutdown()
+    executor.shutdown()
+
+########################################
+# Success, From Constant, Write Response to Blackboard
+########################################
+
+def test_success_write_to_blackboard():
+    console.banner("Client Success, Write to Blackboard")
+
+    server = py_trees_ros.mock.set_bool.SetBoolServer(sleep_time=1.0)
+
+    root = create_service_client(key_response="response")
+    tree = py_trees_ros.trees.BehaviourTree(
+        root=root,
+        unicode_tree_debug=False
+    )
+    tree.setup()
+
+    executor = rclpy.executors.MultiThreadedExecutor(num_threads=4)
+    executor.add_node(server.node)
+    executor.add_node(tree.node)
+
+    assert_banner()
+
+    tree.tick()
+
+    tree.tick_tock(
+        period_ms=100,
+        number_of_iterations=number_of_iterations()
+    )
+
+    while tree.count < number_of_iterations() and root.status == py_trees.common.Status.RUNNING:
+        executor.spin_once(timeout_sec=0.05)
+
+    assert_details("root.status", "SUCCESS", root.status)
+    assert(root.status == py_trees.common.Status.SUCCESS)
+
+    blackboard = py_trees.blackboard.Client()
+    blackboard.register_key(key="response", access=py_trees.common.Access.READ)
+    assert_details("blackboard.response.success", True, blackboard.response.success)
+    assert(blackboard.response.success == True)
+    assert_details("blackboard.response.message", py_trees_ros.mock.set_bool.SetBoolServer.SUCCESS_MESSAGE, blackboard.response.message)
+    assert(blackboard.response.message == py_trees_ros.mock.set_bool.SetBoolServer.SUCCESS_MESSAGE)
+
+    tree.shutdown()
+    server.shutdown()
+    executor.shutdown()
+
+########################################
+# Success, From Blackboard
+########################################
+
+def test_success_from_blackboard():
+    console.banner("Client Success, From Blackboard")
+
+    server = py_trees_ros.mock.set_bool.SetBoolServer(sleep_time=1.0)
+
+    root = create_service_client(from_blackboard=True)
+    tree = py_trees_ros.trees.BehaviourTree(
+        root=root,
+        unicode_tree_debug=False
+    )
+    tree.setup()
+
+    executor = rclpy.executors.MultiThreadedExecutor(num_threads=4)
+    executor.add_node(server.node)
+    executor.add_node(tree.node)
+
+    assert_banner()
+
+    tree.tick()
+
+    # Nothing on blackboard yet
+    assert_details("No request on blackboard - root.status", "FAILURE", root.status)
+    assert(root.status == py_trees.common.Status.FAILURE)
+
+    py_trees.blackboard.Blackboard.set(
+        variable_name="/request",
+        value=SetBool.Request(data=True)  # noqa
+    )
+
+    tree.tick()
+
+    # Request exists on blackboard
+    assert_details("Request exists - root.status", "RUNNING", root.status)
+    assert(root.status == py_trees.common.Status.RUNNING)
+
+    tree.shutdown()
+    server.shutdown()
+    executor.shutdown()
+
+########################################
+# Success, Long Service Call
+########################################
+
+def test_success_long_service_call():
+    console.banner("Client Success, Long Service Call")
+
+    service_time = 5.0 # secs
+    server = py_trees_ros.mock.set_bool.SetBoolServer(sleep_time=service_time)
+
+    root = create_service_client()
+    tree = py_trees_ros.trees.BehaviourTree(
+        root=root,
+        unicode_tree_debug=False
+    )
+    tree.setup()
+
+    executor = rclpy.executors.MultiThreadedExecutor(num_threads=4)
+    executor.add_node(server.node)
+    executor.add_node(tree.node)
+
+    assert_banner()
+
+    assert_details("root.status", "INVALID", root.status)
+    assert(root.status == py_trees.common.Status.INVALID)
+
+    start_time = time.monotonic()
+    while time.monotonic() - start_time < service_time:
+        tree.tick()
+        assert_details("Remaining time %f secs - root.status" % (service_time - (time.monotonic() - start_time)), "RUNNING", root.status)
+        assert(root.status == py_trees.common.Status.RUNNING)
+        time.sleep(0.2)
+        executor.spin_once(timeout_sec=0.05)
+
+    time.sleep(0.2)
+    tree.tick()
+
+    assert_details("root.status", "SUCCESS", root.status)
+    assert(root.status == py_trees.common.Status.SUCCESS)
+
+    tree.shutdown()
+    server.shutdown()
+    executor.shutdown()
+
+########################################
+# Failure, Server does not exist
+########################################
+
+
+def test_failure_server_does_not_exist():
+    console.banner("Client Failure, Server does not exist")
+
+    timeout = 0.1
+    root = create_service_client(from_blackboard=True, wait_for_server_timeout_sec=timeout)
+    tree = py_trees_ros.trees.BehaviourTree(root=root)
+
+    start_time = time.monotonic()
+    try:
+        tree.setup()
+    except py_trees_ros.exceptions.TimedOutError:
+        duration = time.monotonic() - start_time
+    assert_details("Tree Setup Timeout", "delta+{}".format(timeout), duration)
+    assert(duration < 10*timeout)
+
+    tree.shutdown()
+
+########################################
+# Failure, Request of wrong type
+########################################
+
+def test_failure_from_blackboard():
+    console.banner("Client Failure, Request of wrong type")
+
+    server = py_trees_ros.mock.set_bool.SetBoolServer(sleep_time=1.0)
+
+    root = create_service_client(from_blackboard=True)
+    tree = py_trees_ros.trees.BehaviourTree(
+        root=root,
+        unicode_tree_debug=False
+    )
+    tree.setup()
+
+    executor = rclpy.executors.MultiThreadedExecutor(num_threads=4)
+    executor.add_node(server.node)
+    executor.add_node(tree.node)
+
+    assert_banner()
+
+    py_trees.blackboard.Blackboard.set(
+        variable_name="/request",
+        value=Trigger.Request()  # noqa
+    )
+
+    tree.tick()
+
+    # Request of wrong type
+    assert_details("Request of wrong type - root.status", "FAILURE", root.status)
+    assert(root.status == py_trees.common.Status.FAILURE)
+
+    tree.shutdown()
+    server.shutdown()
+    executor.shutdown()
+
+########################################
+# Priority Interrupt
+########################################
+
+def test_priority_interrupt():
+    console.banner("Priority Interrupt")
+
+    sleep_time = 3.0
+    server = py_trees_ros.mock.set_bool.SetBoolServer(sleep_time=sleep_time)
+
+    service_client = create_service_client()
+    success_eventually = py_trees.behaviours.StatusQueue(
+        name="Success Eventually",
+        queue=[
+            py_trees.common.Status.FAILURE,
+        ],
+        eventually=py_trees.common.Status.SUCCESS,
+    )
+    root = py_trees.composites.Selector(name="Selector", memory=False)
+    root.add_children([success_eventually, service_client])
+    tree = py_trees_ros.trees.BehaviourTree(root=root, unicode_tree_debug=False)
+    tree.setup()
+
+    executor = rclpy.executors.MultiThreadedExecutor(num_threads=4)
+    executor.add_node(server.node)
+    executor.add_node(tree.node)
+
+    assert_banner()
+
+    tree.tick()
+
+    assert_details("Pre-failure: service_client.status", "RUNNING", service_client.status)
+    assert(service_client.status == py_trees.common.Status.RUNNING)
+
+    tree.tick()
+
+    assert_details("Post-failure: service_client.status", "INVALID", service_client.status)
+    assert(service_client.status == py_trees.common.Status.INVALID)
+
+    # Sleep longer than sleep time to ensure nothing happens after the server callback ends
+    time.sleep(sleep_time*1.5)
+
+    tree.shutdown()
+    server.shutdown()
+    executor.shutdown()


### PR DESCRIPTION
This PR implements service clients as behaviors. Following the paradigm for action clients, it implements two behaviors: `FromBlackboard`, which reads the request from the blackboard, and `FromConstant`, which always has the same request. Additionally, it has the option to write the service response to the blackboard, by passing in a blackboard key (`key_response`) to write to.

This has been tested on a number of test cases (see `test_service_client.py`). The code has not been through any formatter since I wasn't sure which is used for this repository.

I believe this fulfills Issue #103 .
