### PR TITLE
Add FromCallback service and action client behaviors

### DIFF
--- a/py_trees_ros/action_clients.py
+++ b/py_trees_ros/action_clients.py
@@ -19,6 +19,7 @@ Behaviours for ROS actions.
 
 import typing
 import uuid
+from abc import ABC, abstractmethod
 
 import action_msgs.msg as action_msgs  # GoalStatus
 import py_trees
@@ -480,3 +481,61 @@ class AttributesFromBlackboard(FromBlackboard):
         self.blackboard.set(name=self.key, value=goal)
 
         super().initialise()
+
+
+class FromCallback(FromBlackboard, ABC):
+    """
+    Convenience version of the action client that obtains the goal from a callback implemented by derived classes.
+
+    .. see-also: :class:`py_trees_ros.action_clients.FromBlackboard`
+
+    Args:
+        name: name of the behaviour
+        action_type: spec type for the action (e.g. move_base_msgs.action.MoveBase)
+        action_name: where you can find the action topics & services (e.g. "bob/move_base")
+        generate_feedback_message: formatter for feedback messages, takes action_type.Feedback
+            messages and returns strings (default: None)
+        wait_for_server_timeout_sec: use negative values for a blocking but periodic check (default: -3.0)
+
+    .. note::
+       The default setting for timeouts (a negative value) will suit
+       most use cases. With this setting the behaviour will periodically check and
+       issue a warning if the server can't be found. Actually aborting the setup can
+       usually be left up to the behaviour tree manager.
+    """
+
+    def __init__(self,
+                 name: str,
+                 action_type: typing.Any,
+                 action_name: str,
+                 generate_feedback_message: typing.Callable[[typing.Any], str] = None,
+                 wait_for_server_timeout_sec: float = -3.0
+                 ):
+        unique_id = uuid.uuid4()
+        self.key = "/goal_" + str(unique_id)
+        super().__init__(
+            action_type=action_type,
+            action_name=action_name,
+            key=self.key,
+            name=name,
+            generate_feedback_message=generate_feedback_message,
+            wait_for_server_timeout_sec=wait_for_server_timeout_sec
+        )
+        # The parent constructor already instantiated a blackboard client
+        self.blackboard.register_key(
+            key=self.key,
+            access=py_trees.common.Access.WRITE,
+        )
+
+    def initialise(self):
+        """
+        Call derived class `get_goal` method and write the returned action goal to the blackboard.
+        """
+        self.logger.debug("%s.initialise()" % self.__class__.__name__)
+        self.blackboard.set(name=self.key, value=self.get_goal())
+
+        super().initialise()
+
+    @abstractmethod
+    def get_goal(self):
+        pass

--- a/py_trees_ros/service_clients.py
+++ b/py_trees_ros/service_clients.py
@@ -19,6 +19,7 @@ Behaviours for ROS services.
 from asyncio.tasks import wait_for
 import typing
 import uuid
+from abc import ABC, abstractmethod
 
 import py_trees
 
@@ -148,7 +149,7 @@ class FromBlackboard(py_trees.behaviour.Behaviour):
 
     def initialise(self):
         """
-        Reset the internal variables and kick off a new request request.
+        Reset the internal variables and kick off a new request.
         """
         self.logger.debug("{}.initialise()".format(self.qualified_name))
 
@@ -245,7 +246,7 @@ class FromConstant(FromBlackboard):
                  wait_for_server_timeout_sec: float=-3.0
                  ):
         unique_id = uuid.uuid4()
-        key_request = "/goal_" + str(unique_id)
+        key_request = "/request_" + str(unique_id)
         super().__init__(
             service_type=service_type,
             service_name=service_name,
@@ -313,3 +314,61 @@ class AttributesFromBlackboard(FromBlackboard):
         self.blackboard.set(name=self.key_request, value=request)
 
         super().initialise()
+
+
+class FromCallback(FromBlackboard, ABC):
+    """
+    Convenience version of the service client that obtains the request from a callback implemented
+    by derived classes.
+
+    .. see-also: :class:`py_trees_ros.service_clients.FromBlackboard`
+
+    Args:
+        name: name of the behaviour
+        name: name of the behaviour
+        service_type: spec type for the service
+        service_name: where you can find the service
+        key_response: optional name of the key for the response on the blackboard (default: None)
+        wait_for_server_timeout_sec: use negative values for a blocking but periodic check (default: -3.0)
+
+    .. note::
+       The default setting for timeouts (a negative value) will suit
+       most use cases. With this setting the behaviour will periodically check and
+       issue a warning if the server can't be found. Actually aborting the setup can
+       usually be left up to the behaviour tree manager.
+    """
+    def __init__(self,
+                 name: str,
+                 service_type: typing.Any,
+                 service_name: str,
+                 key_response: typing.Optional[str]=None,
+                 wait_for_server_timeout_sec: float=-3.0
+                 ):
+        unique_id = uuid.uuid4()
+        self.key_request = "/request_" + str(unique_id)
+        super().__init__(
+            service_type=service_type,
+            service_name=service_name,
+            key_request=self.key_request,
+            key_response=key_response,
+            name=name,
+            wait_for_server_timeout_sec=wait_for_server_timeout_sec
+        )
+        # parent already instantiated a blackboard client
+        self.blackboard.register_key(
+            key=self.key_request,
+            access=py_trees.common.Access.WRITE,
+        )
+
+    def initialise(self):
+        """
+        Call derived class `get_request` method and write the returned service request to the blackboard.
+        """
+        self.logger.debug("%s.initialise()" % self.__class__.__name__)
+        self.blackboard.set(name=self.key_request, value=self.get_request())
+
+        super().initialise()
+
+    @abstractmethod
+    def get_request(self):
+        pass

--- a/py_trees_ros/trees.py
+++ b/py_trees_ros/trees.py
@@ -554,7 +554,7 @@ class BehaviourTree(py_trees.trees.BehaviourTree):
         super().shutdown()
         if self.node is not None:
             # shutdown the node - this *should* automagically clean
-            # up any non-estoeric shutdown of ros communications
+            # up any non-esoteric shutdown of ros communications
             # inside behaviours
             self.node.destroy_node()
 

--- a/tests/test_action_client.py
+++ b/tests/test_action_client.py
@@ -361,7 +361,7 @@ def test_failure_from_blackboard():
 
     server = py_trees_ros.mock.dock.Dock(duration=1.5)
 
-    root = create_action_client(from_blackboard=True)
+    root = create_action_client(client_type="from_blackboard")
     tree = py_trees_ros.trees.BehaviourTree(root=root)
 
     # ROS Setup

--- a/tests/test_action_client.py
+++ b/tests/test_action_client.py
@@ -35,8 +35,8 @@ def assert_details(text, expected, result):
           console.reset)
 
 
-def create_action_client(from_blackboard=False, wait_for_server_timeout_sec=2.0):
-    if from_blackboard:
+def create_action_client(client_type="from_constant", wait_for_server_timeout_sec=2.0):
+    if client_type == "from_blackboard":
         behaviour = py_trees_ros.action_clients.FromBlackboard(
             name="dock",
             action_type=py_trees_actions.Dock,
@@ -45,7 +45,7 @@ def create_action_client(from_blackboard=False, wait_for_server_timeout_sec=2.0)
             generate_feedback_message=lambda msg: "{:.2f}%%".format(msg.feedback.percentage_completed),
             wait_for_server_timeout_sec=wait_for_server_timeout_sec
         )
-    else:
+    elif client_type == "from_constant":
         behaviour = py_trees_ros.action_clients.FromConstant(
             name="dock",
             action_type=py_trees_actions.Dock,
@@ -54,6 +54,21 @@ def create_action_client(from_blackboard=False, wait_for_server_timeout_sec=2.0)
             generate_feedback_message=lambda msg: "{:.2f}%%".format(msg.feedback.percentage_completed),
             wait_for_server_timeout_sec=wait_for_server_timeout_sec
         )
+    elif client_type == "from_callback":
+        class Dock(py_trees_ros.action_clients.FromCallback):
+            def get_goal(self):
+                return py_trees_actions.Dock.Goal(dock=True)
+
+        behaviour = Dock(
+            name="dock",
+            action_type=py_trees_actions.Dock,
+            action_name="dock",
+            generate_feedback_message=lambda msg: "{:.2f}%%".format(msg.feedback.percentage_completed),
+            wait_for_server_timeout_sec=wait_for_server_timeout_sec
+        )
+    else:
+        raise ValueError(f"Unknown client type: '{client_type}'")
+
     return behaviour
 
 
@@ -307,7 +322,7 @@ def test_from_blackboard():
 
     server = py_trees_ros.mock.dock.Dock(duration=1.5)
 
-    root = create_action_client(from_blackboard=True)
+    root = create_action_client(client_type="from_blackboard")
     tree = py_trees_ros.trees.BehaviourTree(root=root)
 
     # ROS Setup
@@ -374,6 +389,39 @@ def test_failure_from_blackboard():
     executor.shutdown()
 
 ########################################
+# From Callback
+########################################
+
+
+def test_from_callback():
+    console.banner("From Callback")
+
+    server = py_trees_ros.mock.dock.Dock(duration=1.5)
+
+    root = create_action_client(client_type="from_callback")
+    tree = py_trees_ros.trees.BehaviourTree(root=root)
+
+    # ROS Setup
+    tree.setup()
+    executor = rclpy.executors.MultiThreadedExecutor(num_threads=4)
+    executor.add_node(server.node)
+    executor.add_node(tree.node)
+
+    print("")
+    assert_banner()
+
+    tree.tick()
+
+    # Goal exists on blackboard
+    assert_details("Goal exists - root.status", "RUNNING", root.status)
+    assert(root.status == py_trees.common.Status.RUNNING)
+
+    tree.shutdown()
+    server.shutdown()
+    executor.shutdown()
+
+
+########################################
 # Timeouts
 ########################################
 
@@ -382,7 +430,7 @@ def test_timeouts():
     console.banner("Timeouts")
 
     timeout = 0.1
-    root = create_action_client(from_blackboard=True, wait_for_server_timeout_sec=timeout)
+    root = create_action_client(client_type="from_blackboard", wait_for_server_timeout_sec=timeout)
     tree = py_trees_ros.trees.BehaviourTree(root=root)
 
     start_time = time.monotonic()


### PR DESCRIPTION
It obtains the goal from a callback implemented by derived classes, stores on blackboard, and then works the same as `FromBlackboard`.

This is by far the most convenient way to provide the goal. Both BTT.CPP and SMACH provide similar mechanisms. 