### PR TITLE
Avoid silent failure on service and action client FromBlackboard (#236)

### DIFF
--- a/py_trees_ros/action_clients.py
+++ b/py_trees_ros/action_clients.py
@@ -195,8 +195,13 @@ class FromBlackboard(py_trees.behaviour.Behaviour):
         try:
             self.send_goal_request(self.blackboard.goal)
             self.feedback_message = "sent goal request"
-        except KeyError:
-            pass  # self.send_goal_future will be None, check on that
+        except TypeError:
+            expected_type = self.action_type.Goal.__name__
+            received_type = type(self.blackboard.goal).__name__
+            self.logger.error(f"Received a goal of type <{received_type}> instead of <{expected_type}>")
+        except KeyError as e:
+            self.logger.error(f"{e}")
+        # self.send_goal_future will be None on either exception, and update will return FAILURE
 
     def update(self):
         """

--- a/py_trees_ros/service_clients.py
+++ b/py_trees_ros/service_clients.py
@@ -159,8 +159,9 @@ class FromBlackboard(py_trees.behaviour.Behaviour):
             if self.service_client.service_is_ready():
                 self.service_future = self.service_client.call_async(self.blackboard.request)
         except TypeError:
-            tr, te = type(self.blackboard.request).__name__,  self.service_type.Request.__name__
-            self.logger.error(f"Received a request of type <{tr}> instead of <{te}>")
+            expected_type = self.service_type.Request.__name__
+            received_type = type(self.blackboard.request).__name__
+            self.logger.error(f"Received a request of type <{received_type}> instead of <{expected_type}>")
         except KeyError as e:
             self.logger.error(f"{e}")
         # self.service_future will be None on either exception, and update will return FAILURE

--- a/py_trees_ros/service_clients.py
+++ b/py_trees_ros/service_clients.py
@@ -158,8 +158,12 @@ class FromBlackboard(py_trees.behaviour.Behaviour):
         try:
             if self.service_client.service_is_ready():
                 self.service_future = self.service_client.call_async(self.blackboard.request)
-        except (KeyError, TypeError):
-            pass  # self.service_future will be None, check on that
+        except TypeError:
+            tr, te = type(self.blackboard.request).__name__,  self.service_type.Request.__name__
+            self.logger.error(f"Received a request of type <{tr}> instead of <{te}>")
+        except KeyError as e:
+            self.logger.error(f"{e}")
+        # self.service_future will be None on either exception, and update will return FAILURE
 
     def update(self):
         """

--- a/tests/test_action_client.py
+++ b/tests/test_action_client.py
@@ -340,6 +340,39 @@ def test_from_blackboard():
     server.shutdown()
     executor.shutdown()
 
+
+def test_failure_from_blackboard():
+    console.banner("Client Failure, Goal of wrong type")
+
+    server = py_trees_ros.mock.dock.Dock(duration=1.5)
+
+    root = create_action_client(from_blackboard=True)
+    tree = py_trees_ros.trees.BehaviourTree(root=root)
+
+    # ROS Setup
+    tree.setup()
+    executor = rclpy.executors.MultiThreadedExecutor(num_threads=4)
+    executor.add_node(server.node)
+    executor.add_node(tree.node)
+
+    print("")
+    assert_banner()
+
+    py_trees.blackboard.Blackboard.set(
+        variable_name="/goal",
+        value=py_trees_actions.MoveBase.Goal()  # noqa
+    )
+
+    tree.tick()
+
+    # Goal of wrong type
+    assert_details("Goal of wrong type - root.status", "FAILURE", root.status)
+    assert(root.status == py_trees.common.Status.FAILURE)
+
+    tree.shutdown()
+    server.shutdown()
+    executor.shutdown()
+
 ########################################
 # Timeouts
 ########################################


### PR DESCRIPTION
Trivial fix; repeats what is done [in action client](https://github.com/splintered-reality/py_trees_ros/blob/9326c9df5b603439583d2ad29b50dd3052614630/py_trees_ros/action_clients.py#L198)