### PR TITLE
Fix callback group parameter consistency and remove (most) old-school type hints

### DIFF
--- a/py_trees_ros/action_clients.py
+++ b/py_trees_ros/action_clients.py
@@ -99,9 +99,9 @@ class FromBlackboard(py_trees.behaviour.Behaviour):
                  action_type: typing.Any,
                  action_name: str,
                  key: str,
-                 generate_feedback_message: typing.Callable[[typing.Any], str]=None,
-                 wait_for_server_timeout_sec: float=-3.0,
-                 callback_group: typing.Optional[rclpy.callback_groups.CallbackGroup] = None,
+                 generate_feedback_message: typing.Callable[[typing.Any], str] = None,
+                 wait_for_server_timeout_sec: float = -3.0,
+                 callback_group: rclpy.callback_groups.CallbackGroup | None = None,
                  ):
         super().__init__(name)
         self.action_type = action_type

--- a/py_trees_ros/action_clients.py
+++ b/py_trees_ros/action_clients.py
@@ -101,7 +101,7 @@ class FromBlackboard(py_trees.behaviour.Behaviour):
                  key: str,
                  generate_feedback_message: typing.Callable[[typing.Any], str] = None,
                  wait_for_server_timeout_sec: float = -3.0,
-                 callback_group: rclpy.callback_groups.CallbackGroup | None = None,
+                 callback_group: typing.Optional[rclpy.callback_groups.CallbackGroup] = None,
                  ):
         super().__init__(name)
         self.action_type = action_type
@@ -405,7 +405,7 @@ class FromConstant(FromBlackboard):
                  action_goal: typing.Any,
                  generate_feedback_message: typing.Callable[[typing.Any], str] = None,
                  wait_for_server_timeout_sec: float = -3.0,
-                 callback_group: rclpy.callback_groups.CallbackGroup | None = None,
+                 callback_group: typing.Optional[rclpy.callback_groups.CallbackGroup] = None,
                  ):
         unique_id = uuid.uuid4()
         key = "/goal_" + str(unique_id)
@@ -456,7 +456,7 @@ class AttributesFromBlackboard(FromBlackboard):
                  goal_fields: dict[str, typing.Any],
                  generate_feedback_message: typing.Callable[[typing.Any], str] = None,
                  wait_for_server_timeout_sec: float = -3.0,
-                 callback_group: rclpy.callback_groups.CallbackGroup | None = None,
+                 callback_group: typing.Optional[rclpy.callback_groups.CallbackGroup] = None,
                  ):
         unique_id = uuid.uuid4()
         self.key = "/goal_" + str(unique_id)
@@ -522,7 +522,7 @@ class FromCallback(FromBlackboard, ABC):
                  action_name: str,
                  generate_feedback_message: typing.Callable[[typing.Any], str] = None,
                  wait_for_server_timeout_sec: float = -3.0,
-                 callback_group: rclpy.callback_groups.CallbackGroup | None = None,
+                 callback_group: typing.Optional[rclpy.callback_groups.CallbackGroup] = None,
                  ):
         unique_id = uuid.uuid4()
         self.key = "/goal_" + str(unique_id)

--- a/py_trees_ros/action_clients.py
+++ b/py_trees_ros/action_clients.py
@@ -390,6 +390,7 @@ class FromConstant(FromBlackboard):
         generate_feedback_message: formatter for feedback messages, takes action_type.Feedback
             messages and returns strings (default: None)
         wait_for_server_timeout_sec: use negative values for a blocking but periodic check (default: -3.0)
+        callback_group: callback group for the action client
 
     .. note::
        The default setting for timeouts (a negative value) will suit
@@ -402,8 +403,9 @@ class FromConstant(FromBlackboard):
                  action_type: typing.Any,
                  action_name: str,
                  action_goal: typing.Any,
-                 generate_feedback_message: typing.Callable[[typing.Any], str]=None,
-                 wait_for_server_timeout_sec: float=-3.0
+                 generate_feedback_message: typing.Callable[[typing.Any], str] = None,
+                 wait_for_server_timeout_sec: float = -3.0,
+                 callback_group: rclpy.callback_groups.CallbackGroup | None = None,
                  ):
         unique_id = uuid.uuid4()
         key = "/goal_" + str(unique_id)
@@ -413,7 +415,8 @@ class FromConstant(FromBlackboard):
             key=key,
             name=name,
             generate_feedback_message=generate_feedback_message,
-            wait_for_server_timeout_sec=wait_for_server_timeout_sec
+            wait_for_server_timeout_sec=wait_for_server_timeout_sec,
+            callback_group=callback_group,
         )
         # parent already instantiated a blackboard client
         self.blackboard.register_key(
@@ -437,6 +440,7 @@ class AttributesFromBlackboard(FromBlackboard):
         generate_feedback_message: formatter for feedback messages, takes action_type.Feedback
             messages and returns strings (default: None)
         wait_for_server_timeout_sec: use negative values for a blocking but periodic check (default: -3.0)
+        callback_group: callback group for the action client
 
     .. note::
        The default setting for timeouts (a negative value) will suit
@@ -451,7 +455,8 @@ class AttributesFromBlackboard(FromBlackboard):
                  action_name: str,
                  goal_fields: dict[str, typing.Any],
                  generate_feedback_message: typing.Callable[[typing.Any], str] = None,
-                 wait_for_server_timeout_sec: float = -3.0
+                 wait_for_server_timeout_sec: float = -3.0,
+                 callback_group: rclpy.callback_groups.CallbackGroup | None = None,
                  ):
         unique_id = uuid.uuid4()
         self.key = "/goal_" + str(unique_id)
@@ -461,7 +466,8 @@ class AttributesFromBlackboard(FromBlackboard):
             key=self.key,
             name=name,
             generate_feedback_message=generate_feedback_message,
-            wait_for_server_timeout_sec=wait_for_server_timeout_sec
+            wait_for_server_timeout_sec=wait_for_server_timeout_sec,
+            callback_group=callback_group,
         )
         # The parent constructor already instantiated a blackboard client
         # Here we register the keys from which we will read the goal attributes and a key to store the goal itself
@@ -501,6 +507,7 @@ class FromCallback(FromBlackboard, ABC):
         generate_feedback_message: formatter for feedback messages, takes action_type.Feedback
             messages and returns strings (default: None)
         wait_for_server_timeout_sec: use negative values for a blocking but periodic check (default: -3.0)
+        callback_group: callback group for the action client
 
     .. note::
        The default setting for timeouts (a negative value) will suit
@@ -514,7 +521,8 @@ class FromCallback(FromBlackboard, ABC):
                  action_type: typing.Any,
                  action_name: str,
                  generate_feedback_message: typing.Callable[[typing.Any], str] = None,
-                 wait_for_server_timeout_sec: float = -3.0
+                 wait_for_server_timeout_sec: float = -3.0,
+                 callback_group: rclpy.callback_groups.CallbackGroup | None = None,
                  ):
         unique_id = uuid.uuid4()
         self.key = "/goal_" + str(unique_id)
@@ -524,7 +532,8 @@ class FromCallback(FromBlackboard, ABC):
             key=self.key,
             name=name,
             generate_feedback_message=generate_feedback_message,
-            wait_for_server_timeout_sec=wait_for_server_timeout_sec
+            wait_for_server_timeout_sec=wait_for_server_timeout_sec,
+            callback_group=callback_group,
         )
         # The parent constructor already instantiated a blackboard client
         self.blackboard.register_key(

--- a/py_trees_ros/blackboard.py
+++ b/py_trees_ros/blackboard.py
@@ -29,7 +29,6 @@ import py_trees_ros_interfaces.srv as py_trees_srvs  # noqa
 import rclpy.expand_topic_name
 import rclpy.node
 import std_msgs.msg as std_msgs
-import typing
 import uuid
 
 from . import exceptions
@@ -57,7 +56,7 @@ class SubBlackboard(object):
         self.node = node
         self.warned = False
 
-    def update(self, variable_names: typing.Set[str]):
+    def update(self, variable_names: set[str]):
         """
         Check for changes to the blackboard scoped to the provided set of
         variable names (may be nested, e.g. battery.percentage). Checks
@@ -145,7 +144,7 @@ class BlackboardView(object):
             self,
             node: rclpy.node.Node,
             topic_name: str,
-            variable_names: typing.Set[str],
+            variable_names: set[str],
             filter_on_visited_path: bool,
             with_activity_stream: bool
     ):
@@ -170,7 +169,7 @@ class BlackboardView(object):
         """
         self.node.destroy_publisher(self.publisher)
 
-    def is_changed(self, visited_clients: typing.Set[uuid.UUID]) -> bool:
+    def is_changed(self, visited_clients: set[uuid.UUID]) -> bool:
         """
         Dynamically adjusts the tracking parameters for the sub-blackboard
         against the clients that were visited (if desired) and proceeds
@@ -328,7 +327,7 @@ class Exchange(object):
 
         return variables
 
-    def post_tick_handler(self, visited_client_ids: typing.List[uuid.UUID]=None):
+    def post_tick_handler(self, visited_client_ids: list[uuid.UUID] | None = None):
         """
         Update blackboard watcher views, publish changes and
         clear the activity stream. Publishing is lazy, depending

--- a/py_trees_ros/conversions.py
+++ b/py_trees_ros/conversions.py
@@ -30,7 +30,7 @@ import uuid
 ##############################################################################
 
 
-def activity_stream_to_msgs() -> typing.List[py_trees_ros_interfaces.msg.ActivityItem]:
+def activity_stream_to_msgs() -> list[py_trees_ros_interfaces.msg.ActivityItem]:
     """
     Convert the blackboard activity stream to a message.
 

--- a/py_trees_ros/service_clients.py
+++ b/py_trees_ros/service_clients.py
@@ -72,7 +72,7 @@ class FromBlackboard(py_trees.behaviour.Behaviour):
                  key_request: str,
                  key_response: str | None = None,
                  wait_for_server_timeout_sec: float = -3.0,
-                 callback_group: rclpy.callback_groups.CallbackGroup | None = None,
+                 callback_group: typing.Optional[rclpy.callback_groups.CallbackGroup] = None,
                  ):
         super().__init__(name)
         self.service_type = service_type
@@ -253,7 +253,7 @@ class FromConstant(FromBlackboard):
                  service_request: typing.Any,
                  key_response: str | None = None,
                  wait_for_server_timeout_sec: float = -3.0,
-                 callback_group: rclpy.callback_groups.CallbackGroup | None = None,
+                 callback_group: typing.Optional[rclpy.callback_groups.CallbackGroup] = None,
                  ):
         unique_id = uuid.uuid4()
         key_request = "/request_" + str(unique_id)
@@ -293,7 +293,7 @@ class AttributesFromBlackboard(FromBlackboard):
                  service_name: str,
                  request_fields: dict[str, typing.Any],
                  wait_for_server_timeout_sec: float = -3.0,
-                 callback_group: rclpy.callback_groups.CallbackGroup | None = None,
+                 callback_group: typing.Optional[rclpy.callback_groups.CallbackGroup] = None,
                  ):
         unique_id = uuid.uuid4()
         self.key_request = "/request_" + str(unique_id)
@@ -358,7 +358,7 @@ class FromCallback(FromBlackboard, ABC):
                  service_name: str,
                  key_response: str | None = None,
                  wait_for_server_timeout_sec: float = -3.0,
-                 callback_group: rclpy.callback_groups.CallbackGroup | None = None,
+                 callback_group: typing.Optional[rclpy.callback_groups.CallbackGroup] = None,
                  ):
         unique_id = uuid.uuid4()
         self.key_request = "/request_" + str(unique_id)

--- a/py_trees_ros/service_clients.py
+++ b/py_trees_ros/service_clients.py
@@ -70,8 +70,8 @@ class FromBlackboard(py_trees.behaviour.Behaviour):
                  service_type: typing.Any,
                  service_name: str,
                  key_request: str,
-                 key_response: str | None =None,
-                 wait_for_server_timeout_sec: float=-3.0,
+                 key_response: str | None = None,
+                 wait_for_server_timeout_sec: float = -3.0,
                  callback_group: rclpy.callback_groups.CallbackGroup | None = None,
                  ):
         super().__init__(name)
@@ -238,6 +238,7 @@ class FromConstant(FromBlackboard):
         service_request: the request to send
         key_response: optional name of the key for the response on the blackboard (default: None)
         wait_for_server_timeout_sec: use negative values for a blocking but periodic check (default: -3.0)
+        callback_group: callback group for the service client
 
     .. note::
        The default setting for timeouts (a negative value) will suit
@@ -251,7 +252,8 @@ class FromConstant(FromBlackboard):
                  service_name: str,
                  service_request: typing.Any,
                  key_response: str | None = None,
-                 wait_for_server_timeout_sec: float = -3.0
+                 wait_for_server_timeout_sec: float = -3.0,
+                 callback_group: rclpy.callback_groups.CallbackGroup | None = None,
                  ):
         unique_id = uuid.uuid4()
         key_request = "/request_" + str(unique_id)
@@ -261,7 +263,8 @@ class FromConstant(FromBlackboard):
             key_request=key_request,
             key_response=key_response,
             name=name,
-            wait_for_server_timeout_sec=wait_for_server_timeout_sec
+            wait_for_server_timeout_sec=wait_for_server_timeout_sec,
+            callback_group=callback_group,
         )
         # parent already instantiated a blackboard client
         self.blackboard.register_key(
@@ -281,6 +284,7 @@ class AttributesFromBlackboard(FromBlackboard):
         service_name (str): Endpoint of the service
         request_fields (dict[str, typing.Any]): Fields of the request mapped to blackboard variables
         wait_for_server_timeout_sec (float, optional): Wait timeout for the service. Defaults to -3.0.
+        callback_group: callback group for the service client
     """
 
     def __init__(self,
@@ -288,7 +292,8 @@ class AttributesFromBlackboard(FromBlackboard):
                  service_type: typing.Any,
                  service_name: str,
                  request_fields: dict[str, typing.Any],
-                 wait_for_server_timeout_sec: float = -3.0
+                 wait_for_server_timeout_sec: float = -3.0,
+                 callback_group: rclpy.callback_groups.CallbackGroup | None = None,
                  ):
         unique_id = uuid.uuid4()
         self.key_request = "/request_" + str(unique_id)
@@ -297,18 +302,19 @@ class AttributesFromBlackboard(FromBlackboard):
             service_name=service_name,
             key_request=self.key_request,
             name=name,
-            wait_for_server_timeout_sec=wait_for_server_timeout_sec
+            wait_for_server_timeout_sec=wait_for_server_timeout_sec,
+            callback_group=callback_group,
         )
         # The parent constructor already instantiated a blackboard client
         self.request_fields = request_fields
         for bb_key in self.request_fields.values():
             self.blackboard.register_key(
                 key=bb_key,
-                access=bt.common.Access.READ,
+                access=py_trees.common.Access.READ,
             )
         self.blackboard.register_key(
             key=self.key_request,
-            access=bt.common.Access.WRITE,
+            access=py_trees.common.Access.WRITE,
         )
 
     def initialise(self):
@@ -338,6 +344,7 @@ class FromCallback(FromBlackboard, ABC):
         service_name: where you can find the service
         key_response: optional name of the key for the response on the blackboard (default: None)
         wait_for_server_timeout_sec: use negative values for a blocking but periodic check (default: -3.0)
+        callback_group: callback group for the service client
 
     .. note::
        The default setting for timeouts (a negative value) will suit
@@ -350,7 +357,8 @@ class FromCallback(FromBlackboard, ABC):
                  service_type: typing.Any,
                  service_name: str,
                  key_response: str | None = None,
-                 wait_for_server_timeout_sec: float = -3.0
+                 wait_for_server_timeout_sec: float = -3.0,
+                 callback_group: rclpy.callback_groups.CallbackGroup | None = None,
                  ):
         unique_id = uuid.uuid4()
         self.key_request = "/request_" + str(unique_id)
@@ -360,7 +368,8 @@ class FromCallback(FromBlackboard, ABC):
             key_request=self.key_request,
             key_response=key_response,
             name=name,
-            wait_for_server_timeout_sec=wait_for_server_timeout_sec
+            wait_for_server_timeout_sec=wait_for_server_timeout_sec,
+            callback_group=callback_group,
         )
         # parent already instantiated a blackboard client
         self.blackboard.register_key(

--- a/py_trees_ros/service_clients.py
+++ b/py_trees_ros/service_clients.py
@@ -70,9 +70,9 @@ class FromBlackboard(py_trees.behaviour.Behaviour):
                  service_type: typing.Any,
                  service_name: str,
                  key_request: str,
-                 key_response: typing.Optional[str]=None,
+                 key_response: str | None =None,
                  wait_for_server_timeout_sec: float=-3.0,
-                 callback_group: typing.Optional[rclpy.callback_groups.CallbackGroup] = None,
+                 callback_group: rclpy.callback_groups.CallbackGroup | None = None,
                  ):
         super().__init__(name)
         self.service_type = service_type
@@ -250,8 +250,8 @@ class FromConstant(FromBlackboard):
                  service_type: typing.Any,
                  service_name: str,
                  service_request: typing.Any,
-                 key_response: typing.Optional[str]=None,
-                 wait_for_server_timeout_sec: float=-3.0
+                 key_response: str | None = None,
+                 wait_for_server_timeout_sec: float = -3.0
                  ):
         unique_id = uuid.uuid4()
         key_request = "/request_" + str(unique_id)
@@ -349,8 +349,8 @@ class FromCallback(FromBlackboard, ABC):
                  name: str,
                  service_type: typing.Any,
                  service_name: str,
-                 key_response: typing.Optional[str]=None,
-                 wait_for_server_timeout_sec: float=-3.0
+                 key_response: str | None = None,
+                 wait_for_server_timeout_sec: float = -3.0
                  ):
         unique_id = uuid.uuid4()
         self.key_request = "/request_" + str(unique_id)

--- a/py_trees_ros/subscribers.py
+++ b/py_trees_ros/subscribers.py
@@ -133,7 +133,7 @@ class Handler(py_trees.behaviour.Behaviour):
             if self.clearing_policy == py_trees.common.ClearingPolicy.ON_INITIALISE:
                 self.msg = None
 
-    def _callback(self, msg):
+    def _callback(self, msg: typing.Any):
         """
         The subscriber callback, just stores a copy of the message internally.
 
@@ -173,6 +173,7 @@ class CheckData(Handler):
         comparison_operator: one from the python `operator module`_
         fail_if_no_data: :attr:`~py_trees.common.Status.FAILURE` instead of :attr:`~py_trees.common.Status.RUNNING` if there is no data yet
         fail_if_bad_comparison: :attr:`~py_trees.common.Status.FAILURE` instead of :attr:`~py_trees.common.Status.RUNNING` if comparison failed
+        callback_group: callback group for the subscriber
         clearing_policy: when to clear the data
 
     .. tip::
@@ -190,16 +191,18 @@ class CheckData(Handler):
                  qos_profile: rclpy.qos.QoSProfile,
                  variable_name: str,
                  expected_value: typing.Any,
-                 comparison_operator=operator.eq,
-                 fail_if_no_data=False,
-                 fail_if_bad_comparison=False,
-                 clearing_policy=py_trees.common.ClearingPolicy.ON_INITIALISE
+                 comparison_operator: typing.Callable = operator.eq,
+                 fail_if_no_data: bool = False,
+                 fail_if_bad_comparison: bool = False,
+                 callback_group: rclpy.callback_groups.CallbackGroup | None = None,
+                 clearing_policy: py_trees.common.ClearingPolicy = py_trees.common.ClearingPolicy.ON_INITIALISE,
                  ):
         super(CheckData, self).__init__(
             name=name,
             topic_name=topic_name,
             topic_type=topic_type,
             qos_profile=qos_profile,
+            callback_group=callback_group,
             clearing_policy=clearing_policy,
         )
         self.variable_name = variable_name
@@ -284,6 +287,7 @@ class WaitForData(Handler):
         topic_type: class of the message type (e.g. :obj:`std_msgs.msg.String`)
         qos_profile: qos profile for the subscriber
         name: name of the behaviour
+        callback_group: callback group for the subscriber
         clearing_policy: when to clear the data
     """
     def __init__(self,
@@ -291,13 +295,15 @@ class WaitForData(Handler):
                  topic_name: str,
                  topic_type: typing.Any,
                  qos_profile: rclpy.qos.QoSProfile,
-                 clearing_policy=py_trees.common.ClearingPolicy.ON_INITIALISE
+                 callback_group: rclpy.callback_groups.CallbackGroup | None = None,
+                 clearing_policy: py_trees.common.ClearingPolicy = py_trees.common.ClearingPolicy.ON_INITIALISE
                  ):
         super().__init__(
             name=name,
             topic_name=topic_name,
             topic_type=topic_type,
             qos_profile=qos_profile,
+            callback_group=callback_group,
             clearing_policy=clearing_policy
         )
 
@@ -334,6 +340,7 @@ class ToBlackboard(Handler):
         blackboard_variables: blackboard variable string or dict {names (keys) - message subfields (values)}, use a value of None to indicate the entire message
         initialise_variables: initialise the blackboard variables to some defaults
         name: name of the behaviour
+        callback_group: callback group for the subscriber
         clearing_policy: when to clear the data
 
     Examples:
@@ -367,15 +374,17 @@ class ToBlackboard(Handler):
                  topic_name: str,
                  topic_type: typing.Any,
                  qos_profile: rclpy.qos.QoSProfile,
-                 blackboard_variables: typing.Dict[str, typing.Any]={},  # e.g. {"chatter": None}
-                 initialise_variables: typing.Dict[str, typing.Any]={},
-                 clearing_policy=py_trees.common.ClearingPolicy.ON_INITIALISE
+                 blackboard_variables: dict[str, typing.Any]={},  # e.g. {"chatter": None}
+                 initialise_variables: dict[str, typing.Any]={},
+                 callback_group: rclpy.callback_groups.CallbackGroup | None = None,
+                 clearing_policy: py_trees.common.ClearingPolicy = py_trees.common.ClearingPolicy.ON_INITIALISE
                  ):
         super().__init__(
             name=name,
             topic_name=topic_name,
             topic_type=topic_type,
             qos_profile=qos_profile,
+            callback_group=callback_group,
             clearing_policy=clearing_policy
         )
         self.blackboard = self.attach_blackboard_client(name=self.name)
@@ -453,18 +462,21 @@ class EventToBlackboard(Handler):
         topic_name: name of the topic to connect to
         qos_profile: qos profile for the subscriber
         variable_name: name to write the boolean result on the blackboard
+        callback_group: callback group for the subscriber
     """
     def __init__(self,
                  name: str,
                  topic_name: str,
                  qos_profile: rclpy.qos.QoSProfile,
                  variable_name: str,
+                 callback_group: rclpy.callback_groups.CallbackGroup | None = None,
                  ):
         super().__init__(
             name=name,
             topic_name=topic_name,
             topic_type=std_msgs.Empty,
             qos_profile=qos_profile,
+            callback_group=callback_group,
             clearing_policy=py_trees.common.ClearingPolicy.ON_SUCCESS
         )
         self.variable_name = variable_name

--- a/py_trees_ros/subscribers.py
+++ b/py_trees_ros/subscribers.py
@@ -85,8 +85,8 @@ class Handler(py_trees.behaviour.Behaviour):
                  topic_name: str,
                  topic_type: typing.Any,
                  qos_profile: rclpy.qos.QoSProfile,
-                 callback_group: typing.Optional[rclpy.callback_groups.CallbackGroup] = None,
-                 clearing_policy: py_trees.common.ClearingPolicy=py_trees.common.ClearingPolicy.ON_INITIALISE
+                 callback_group: rclpy.callback_groups.CallbackGroup | None = None,
+                 clearing_policy: py_trees.common.ClearingPolicy = py_trees.common.ClearingPolicy.ON_INITIALISE
                  ):
         super(Handler, self).__init__(name=name)
         self.topic_name = topic_name

--- a/py_trees_ros/subscribers.py
+++ b/py_trees_ros/subscribers.py
@@ -85,7 +85,7 @@ class Handler(py_trees.behaviour.Behaviour):
                  topic_name: str,
                  topic_type: typing.Any,
                  qos_profile: rclpy.qos.QoSProfile,
-                 callback_group: rclpy.callback_groups.CallbackGroup | None = None,
+                 callback_group: typing.Optional[rclpy.callback_groups.CallbackGroup] = None,
                  clearing_policy: py_trees.common.ClearingPolicy = py_trees.common.ClearingPolicy.ON_INITIALISE
                  ):
         super(Handler, self).__init__(name=name)
@@ -194,7 +194,7 @@ class CheckData(Handler):
                  comparison_operator: typing.Callable = operator.eq,
                  fail_if_no_data: bool = False,
                  fail_if_bad_comparison: bool = False,
-                 callback_group: rclpy.callback_groups.CallbackGroup | None = None,
+                 callback_group: typing.Optional[rclpy.callback_groups.CallbackGroup] = None,
                  clearing_policy: py_trees.common.ClearingPolicy = py_trees.common.ClearingPolicy.ON_INITIALISE,
                  ):
         super(CheckData, self).__init__(
@@ -295,7 +295,7 @@ class WaitForData(Handler):
                  topic_name: str,
                  topic_type: typing.Any,
                  qos_profile: rclpy.qos.QoSProfile,
-                 callback_group: rclpy.callback_groups.CallbackGroup | None = None,
+                 callback_group: typing.Optional[rclpy.callback_groups.CallbackGroup] = None,
                  clearing_policy: py_trees.common.ClearingPolicy = py_trees.common.ClearingPolicy.ON_INITIALISE
                  ):
         super().__init__(
@@ -376,7 +376,7 @@ class ToBlackboard(Handler):
                  qos_profile: rclpy.qos.QoSProfile,
                  blackboard_variables: dict[str, typing.Any]={},  # e.g. {"chatter": None}
                  initialise_variables: dict[str, typing.Any]={},
-                 callback_group: rclpy.callback_groups.CallbackGroup | None = None,
+                 callback_group: typing.Optional[rclpy.callback_groups.CallbackGroup] = None,
                  clearing_policy: py_trees.common.ClearingPolicy = py_trees.common.ClearingPolicy.ON_INITIALISE
                  ):
         super().__init__(
@@ -469,7 +469,7 @@ class EventToBlackboard(Handler):
                  topic_name: str,
                  qos_profile: rclpy.qos.QoSProfile,
                  variable_name: str,
-                 callback_group: rclpy.callback_groups.CallbackGroup | None = None,
+                 callback_group: typing.Optional[rclpy.callback_groups.CallbackGroup] = None,
                  ):
         super().__init__(
             name=name,

--- a/py_trees_ros/trees.py
+++ b/py_trees_ros/trees.py
@@ -29,7 +29,6 @@ import statistics
 import subprocess
 import tempfile
 import time
-import typing
 import uuid
 
 import diagnostic_msgs.msg as diagnostic_msgs  # noqa
@@ -148,8 +147,8 @@ class SnapshotStream(object):
             root: py_trees.behaviour.Behaviour,
             changed: bool,
             statistics: py_trees_msgs.Statistics,
-            visited_behaviour_ids: typing.Set[uuid.UUID],
-            visited_blackboard_client_ids: typing.Set[uuid.UUID]
+            visited_behaviour_ids: set[uuid.UUID],
+            visited_blackboard_client_ids: set[uuid.UUID]
     ):
         """"
         Publish a snapshot, including only what has been parameterised.
@@ -275,10 +274,10 @@ class BehaviourTree(py_trees.trees.BehaviourTree):
 
     def setup(
             self,
-            node: typing.Optional[rclpy.node.Node]=None,
-            node_name: str="tree",
-            timeout: float=py_trees.common.Duration.INFINITE,
-            visitor: typing.Optional[py_trees.visitors.VisitorBase]=None,
+            node: rclpy.node.Node | None = None,
+            node_name: str = "tree",
+            timeout: float = py_trees.common.Duration.INFINITE,
+            visitor: py_trees.visitors.VisitorBase | None = None,
             **kwargs: int
     ):
         """
@@ -459,7 +458,7 @@ class BehaviourTree(py_trees.trees.BehaviourTree):
 
     def _set_parameters_callback(
         self,
-        parameters: typing.List[rclpy.parameter.Parameter]
+        parameters: list[rclpy.parameter.Parameter]
     ) -> rcl_interfaces_msgs.SetParametersResult:
         """
         Callback that dynamically handles changes in parameters.

--- a/py_trees_ros/trees.py
+++ b/py_trees_ros/trees.py
@@ -29,6 +29,7 @@ import statistics
 import subprocess
 import tempfile
 import time
+import typing
 import uuid
 
 import diagnostic_msgs.msg as diagnostic_msgs  # noqa
@@ -274,7 +275,7 @@ class BehaviourTree(py_trees.trees.BehaviourTree):
 
     def setup(
             self,
-            node: rclpy.node.Node | None = None,
+            node: typing.Optional[rclpy.node.Node] = None,
             node_name: str = "tree",
             timeout: float = py_trees.common.Duration.INFINITE,
             visitor: py_trees.visitors.VisitorBase | None = None,

--- a/py_trees_ros/utilities.py
+++ b/py_trees_ros/utilities.py
@@ -25,7 +25,6 @@ import rclpy
 import rclpy.node
 import rclpy.qos
 import time
-import typing
 
 from . import exceptions
 
@@ -86,7 +85,7 @@ def find_topics(
         node: rclpy.node.Node,
         topic_type: str,
         namespace: str=None,
-        timeout: float=0.5) -> typing.List[str]:
+        timeout: float=0.5) -> list[str]:
     """
     Discover a topic of the specified type and if necessary, under the specified
     namespace.


### PR DESCRIPTION
This PR fixes the consistent use of `callback_groups` parameters for all child classes of the subscriber, service, and action client behaviors.

Also removes old school type hints like `typing.List`, `typing.Dict`, `typing.Optional`. They are no longer necessary as of Python 3.9, which we're not supporting now (going 3.10 onwards at the moment) -- this with the exception of some ROS types which was failing docs and I can't be bothered to fix it.